### PR TITLE
feat: HC Alphabet Structure + HC Route + 57-Country Tiers + 8 Revenue Rails

### DIFF
--- a/core/hc-platform-registry.ts
+++ b/core/hc-platform-registry.ts
@@ -1,0 +1,161 @@
+/**
+ * HC Platform Registry — The Alphabet Structure
+ * 
+ * Haul Command operates like Alphabet/Google:
+ * One parent company, multiple verticals, each owning a rail.
+ * Every dollar in the freight ecosystem flows through HC.
+ * 
+ * CANONICAL SOURCE OF TRUTH for:
+ * - 8 HC Divisions (the Alphabet analogs)
+ * - 8 Revenue Rails
+ * - 57-Country Tier System
+ * - Platform-wide constants
+ */
+
+import { HC_COUNTRY_TIERS, type CountryTier, type CountryEntry } from './hc-route/country-tiers';
+import { HC_REVENUE_RAILS, type RevenueRail } from './hc-route/revenue-rails';
+
+// ─── HC DIVISIONS (The Alphabet Structure) ────────────────────────────
+
+export interface HCDivision {
+  id: string;
+  name: string;
+  tagline: string;
+  alphabetAnalog: string;
+  description: string;
+  revenueRails: string[];
+  status: 'active' | 'beta' | 'planned';
+}
+
+export const HC_DIVISIONS: Record<string, HCDivision> = {
+  'hc-track': {
+    id: 'hc-track',
+    name: 'HC Track',
+    tagline: 'Every vehicle, everywhere',
+    alphabetAnalog: 'Google Maps',
+    description: 'GPS tracking and fleet visibility powered by Traccar. Real-time location, geofencing, telemetry for every vehicle in the HC ecosystem.',
+    revenueRails: ['track-subscriptions'],
+    status: 'planned',
+  },
+  'hc-load-marketplace': {
+    id: 'hc-load-marketplace',
+    name: 'HC Load Marketplace',
+    tagline: 'The default for freight matching',
+    alphabetAnalog: 'Google Search',
+    description: 'Load board and freight matching engine. Operators find loads, brokers find carriers. HC is the default search engine for freight.',
+    revenueRails: ['load-fees'],
+    status: 'active',
+  },
+  'hc-adgrid': {
+    id: 'hc-adgrid',
+    name: 'HC AdGrid',
+    tagline: 'Vendors pay to reach operators',
+    alphabetAnalog: 'Google Ads',
+    description: 'Contextual advertising network for the freight industry. Tire shops, insurance, fuel, parts — all bid for operator attention.',
+    revenueRails: ['adgrid-revenue'],
+    status: 'active',
+  },
+  'hc-pay': {
+    id: 'hc-pay',
+    name: 'HC Pay',
+    tagline: 'Every transaction flows through Stripe',
+    alphabetAnalog: 'Google Pay',
+    description: 'Payment rails for every transaction in the HC ecosystem. Load payments, subscriptions, marketplace purchases, ad spend — all through Stripe.',
+    revenueRails: ['load-fees'],
+    status: 'active',
+  },
+  'hc-intelligence': {
+    id: 'hc-intelligence',
+    name: 'HC Intelligence',
+    tagline: 'Data products and ML/AI on telemetry',
+    alphabetAnalog: 'DeepMind',
+    description: 'Data lake and intelligence layer. Rate prediction, demand forecasting, safety scoring, route optimization ML models. TimescaleDB on Supabase PostgreSQL.',
+    revenueRails: ['data-intelligence'],
+    status: 'planned',
+  },
+  'hc-developer-platform': {
+    id: 'hc-developer-platform',
+    name: 'HC Developer Platform',
+    tagline: 'APIs others build on',
+    alphabetAnalog: 'Google Cloud',
+    description: 'Public REST APIs for tracking, loads, payments, routing. Third parties build on HC infrastructure and pay for access.',
+    revenueRails: ['api-access-fees'],
+    status: 'beta',
+  },
+  'hc-marketplace': {
+    id: 'hc-marketplace',
+    name: 'HC Marketplace',
+    tagline: '30% clip on every extension',
+    alphabetAnalog: 'Google Play Store',
+    description: 'App store for freight. Third-party developers build extensions, integrations, and tools. HC takes 30% commission on every sale.',
+    revenueRails: ['marketplace-commissions'],
+    status: 'planned',
+  },
+  'hc-capital': {
+    id: 'hc-capital',
+    name: 'HC Capital',
+    tagline: 'Finance operators, earn interest',
+    alphabetAnalog: 'Google Ventures',
+    description: 'Financing arm for operators. Equipment loans, factoring, working capital. HC earns interest on every dollar deployed.',
+    revenueRails: ['capital-interest'],
+    status: 'planned',
+  },
+} as const;
+
+// ─── HC ROUTE (Net-New Division — Oversize Load Routing) ──────────────
+
+export const HC_ROUTE = {
+  id: 'hc-route',
+  name: 'HC Route',
+  tagline: 'Permit-aware oversize load routing',
+  alphabetAnalog: 'Waze + PC*Miler killer',
+  description: 'The only GPS routing engine purpose-built for oversized loads. Permit-aware, constraint-aware (bridge heights, road widths, weight limits), crowd-sourced hazard reporting. Built on GraphHopper + FHWA NBI + OpenStreetMap.',
+  revenueRails: ['track-subscriptions'],
+  status: 'planned' as const,
+  techStack: {
+    routingEngine: 'GraphHopper (Apache 2.0)',
+    bridgeData: 'FHWA National Bridge Inventory (620K+ bridges)',
+    mapData: 'OpenStreetMap (maxheight, maxweight, hgv tags)',
+    crowdSourced: 'HC Waze (in-app hazard reporting)',
+    wazeIntegration: 'Waze Connected Citizens Program (free data feed)',
+    database: 'Supabase PostgreSQL + PostGIS',
+    permitParser: 'OCR + LLM (permit PDF → GPS waypoints)',
+  },
+  dataSources: [
+    { name: 'FHWA National Bridge Inventory', records: '620,000+', format: 'CSV', coverage: 'All US bridges', cost: 'Free' },
+    { name: 'OpenStreetMap', records: 'Global', format: 'OSM PBF', coverage: 'Global', cost: 'Free' },
+    { name: 'State DOT Data', records: 'Varies', format: 'APIs/GIS/PDFs', coverage: 'Per-state', cost: 'Free' },
+    { name: 'Waze CCP Feed', records: 'Real-time', format: 'CIFS/JSON', coverage: 'US', cost: 'Free (partner program)' },
+    { name: 'HC Crowd-Sourced', records: 'Growing', format: 'PostgreSQL', coverage: 'HC users', cost: 'Free (user-generated)' },
+  ],
+  competitors: [
+    { name: 'Google Maps', gap: 'Zero truck awareness. No height/weight/width.' },
+    { name: 'SmartTruckRoute', gap: 'No permit integration. No crowd-sourcing.' },
+    { name: 'PC*Miler', gap: 'Expensive. Not mobile-first. No crowd-sourcing.' },
+    { name: 'Oversize.IO', gap: 'Routing is basic. No real-time navigation.' },
+    { name: 'ProMiles', gap: 'Limited state coverage. Not a full nav system.' },
+  ],
+} as const;
+
+// ─── PLATFORM CONSTANTS ───────────────────────────────────────────────
+
+export const HC_PLATFORM = {
+  name: 'Haul Command',
+  tagline: 'The Operating System for Freight',
+  model: 'Start as the default (Uber model), scale as the parent company (Alphabet model)',
+  totalDivisions: Object.keys(HC_DIVISIONS).length + 1, // +1 for HC Route
+  totalRevenueRails: 8,
+  totalCountries: 57,
+  principles: [
+    'Own the rails — no money leaves the ecosystem',
+    'Default setting — like Uber, be the first choice',
+    'Alphabet structure — each division owns a vertical',
+    'Upgrade, never downgrade — every change makes the platform stronger',
+    'Crowd-sourced intelligence — every user is a data source',
+  ],
+} as const;
+
+// ─── RE-EXPORTS ───────────────────────────────────────────────────────
+
+export { HC_COUNTRY_TIERS, HC_REVENUE_RAILS };
+export type { CountryTier, CountryEntry, RevenueRail };

--- a/core/hc-route/country-tiers.ts
+++ b/core/hc-route/country-tiers.ts
@@ -1,0 +1,127 @@
+/**
+ * HC Country Tiers — Canonical 57-Country System
+ * 
+ * CANONICAL SOURCE OF TRUTH for country tier assignments.
+ * This file supersedes any other country lists in the codebase.
+ * 
+ * Tier A — Gold (10): Premium markets, full feature set, priority support
+ * Tier B — Blue (18): Strong markets, full features, standard support  
+ * Tier C — Silver (26): Growth markets, core features, community support
+ * Tier D — Slate (3): Emerging markets, basic features, self-serve
+ */
+
+export type CountryTier = 'gold' | 'blue' | 'silver' | 'slate';
+
+export interface CountryEntry {
+  code: string;      // ISO 3166-1 alpha-2
+  name: string;
+  tier: CountryTier;
+  flag: string;      // Emoji flag
+  currency: string;  // ISO 4217
+  region: string;
+}
+
+export const HC_COUNTRY_TIERS: Record<CountryTier, CountryEntry[]> = {
+  gold: [
+    { code: 'US', name: 'United States', tier: 'gold', flag: '🇺🇸', currency: 'USD', region: 'North America' },
+    { code: 'CA', name: 'Canada', tier: 'gold', flag: '🇨🇦', currency: 'CAD', region: 'North America' },
+    { code: 'AU', name: 'Australia', tier: 'gold', flag: '🇦🇺', currency: 'AUD', region: 'Oceania' },
+    { code: 'GB', name: 'United Kingdom', tier: 'gold', flag: '🇬🇧', currency: 'GBP', region: 'Europe' },
+    { code: 'NZ', name: 'New Zealand', tier: 'gold', flag: '🇳🇿', currency: 'NZD', region: 'Oceania' },
+    { code: 'ZA', name: 'South Africa', tier: 'gold', flag: '🇿🇦', currency: 'ZAR', region: 'Africa' },
+    { code: 'DE', name: 'Germany', tier: 'gold', flag: '🇩🇪', currency: 'EUR', region: 'Europe' },
+    { code: 'NL', name: 'Netherlands', tier: 'gold', flag: '🇳🇱', currency: 'EUR', region: 'Europe' },
+    { code: 'AE', name: 'United Arab Emirates', tier: 'gold', flag: '🇦🇪', currency: 'AED', region: 'Middle East' },
+    { code: 'BR', name: 'Brazil', tier: 'gold', flag: '🇧🇷', currency: 'BRL', region: 'South America' },
+  ],
+  blue: [
+    { code: 'IE', name: 'Ireland', tier: 'blue', flag: '🇮🇪', currency: 'EUR', region: 'Europe' },
+    { code: 'SE', name: 'Sweden', tier: 'blue', flag: '🇸🇪', currency: 'SEK', region: 'Europe' },
+    { code: 'NO', name: 'Norway', tier: 'blue', flag: '🇳🇴', currency: 'NOK', region: 'Europe' },
+    { code: 'DK', name: 'Denmark', tier: 'blue', flag: '🇩🇰', currency: 'DKK', region: 'Europe' },
+    { code: 'FI', name: 'Finland', tier: 'blue', flag: '🇫🇮', currency: 'EUR', region: 'Europe' },
+    { code: 'BE', name: 'Belgium', tier: 'blue', flag: '🇧🇪', currency: 'EUR', region: 'Europe' },
+    { code: 'AT', name: 'Austria', tier: 'blue', flag: '🇦🇹', currency: 'EUR', region: 'Europe' },
+    { code: 'CH', name: 'Switzerland', tier: 'blue', flag: '🇨🇭', currency: 'CHF', region: 'Europe' },
+    { code: 'ES', name: 'Spain', tier: 'blue', flag: '🇪🇸', currency: 'EUR', region: 'Europe' },
+    { code: 'FR', name: 'France', tier: 'blue', flag: '🇫🇷', currency: 'EUR', region: 'Europe' },
+    { code: 'IT', name: 'Italy', tier: 'blue', flag: '🇮🇹', currency: 'EUR', region: 'Europe' },
+    { code: 'PT', name: 'Portugal', tier: 'blue', flag: '🇵🇹', currency: 'EUR', region: 'Europe' },
+    { code: 'SA', name: 'Saudi Arabia', tier: 'blue', flag: '🇸🇦', currency: 'SAR', region: 'Middle East' },
+    { code: 'QA', name: 'Qatar', tier: 'blue', flag: '🇶🇦', currency: 'QAR', region: 'Middle East' },
+    { code: 'MX', name: 'Mexico', tier: 'blue', flag: '🇲🇽', currency: 'MXN', region: 'North America' },
+    { code: 'IN', name: 'India', tier: 'blue', flag: '🇮🇳', currency: 'INR', region: 'Asia' },
+    { code: 'ID', name: 'Indonesia', tier: 'blue', flag: '🇮🇩', currency: 'IDR', region: 'Asia' },
+    { code: 'TH', name: 'Thailand', tier: 'blue', flag: '🇹🇭', currency: 'THB', region: 'Asia' },
+  ],
+  silver: [
+    { code: 'PL', name: 'Poland', tier: 'silver', flag: '🇵🇱', currency: 'PLN', region: 'Europe' },
+    { code: 'CZ', name: 'Czech Republic', tier: 'silver', flag: '🇨🇿', currency: 'CZK', region: 'Europe' },
+    { code: 'SK', name: 'Slovakia', tier: 'silver', flag: '🇸🇰', currency: 'EUR', region: 'Europe' },
+    { code: 'HU', name: 'Hungary', tier: 'silver', flag: '🇭🇺', currency: 'HUF', region: 'Europe' },
+    { code: 'SI', name: 'Slovenia', tier: 'silver', flag: '🇸🇮', currency: 'EUR', region: 'Europe' },
+    { code: 'EE', name: 'Estonia', tier: 'silver', flag: '🇪🇪', currency: 'EUR', region: 'Europe' },
+    { code: 'LV', name: 'Latvia', tier: 'silver', flag: '🇱🇻', currency: 'EUR', region: 'Europe' },
+    { code: 'LT', name: 'Lithuania', tier: 'silver', flag: '🇱🇹', currency: 'EUR', region: 'Europe' },
+    { code: 'HR', name: 'Croatia', tier: 'silver', flag: '🇭🇷', currency: 'EUR', region: 'Europe' },
+    { code: 'RO', name: 'Romania', tier: 'silver', flag: '🇷🇴', currency: 'RON', region: 'Europe' },
+    { code: 'BG', name: 'Bulgaria', tier: 'silver', flag: '🇧🇬', currency: 'BGN', region: 'Europe' },
+    { code: 'GR', name: 'Greece', tier: 'silver', flag: '🇬🇷', currency: 'EUR', region: 'Europe' },
+    { code: 'TR', name: 'Turkey', tier: 'silver', flag: '🇹🇷', currency: 'TRY', region: 'Europe/Asia' },
+    { code: 'KW', name: 'Kuwait', tier: 'silver', flag: '🇰🇼', currency: 'KWD', region: 'Middle East' },
+    { code: 'OM', name: 'Oman', tier: 'silver', flag: '🇴🇲', currency: 'OMR', region: 'Middle East' },
+    { code: 'BH', name: 'Bahrain', tier: 'silver', flag: '🇧🇭', currency: 'BHD', region: 'Middle East' },
+    { code: 'SG', name: 'Singapore', tier: 'silver', flag: '🇸🇬', currency: 'SGD', region: 'Asia' },
+    { code: 'MY', name: 'Malaysia', tier: 'silver', flag: '🇲🇾', currency: 'MYR', region: 'Asia' },
+    { code: 'JP', name: 'Japan', tier: 'silver', flag: '🇯🇵', currency: 'JPY', region: 'Asia' },
+    { code: 'KR', name: 'South Korea', tier: 'silver', flag: '🇰🇷', currency: 'KRW', region: 'Asia' },
+    { code: 'CL', name: 'Chile', tier: 'silver', flag: '🇨🇱', currency: 'CLP', region: 'South America' },
+    { code: 'AR', name: 'Argentina', tier: 'silver', flag: '🇦🇷', currency: 'ARS', region: 'South America' },
+    { code: 'CO', name: 'Colombia', tier: 'silver', flag: '🇨🇴', currency: 'COP', region: 'South America' },
+    { code: 'PE', name: 'Peru', tier: 'silver', flag: '🇵🇪', currency: 'PEN', region: 'South America' },
+    { code: 'VN', name: 'Vietnam', tier: 'silver', flag: '🇻🇳', currency: 'VND', region: 'Asia' },
+    { code: 'PH', name: 'Philippines', tier: 'silver', flag: '🇵🇭', currency: 'PHP', region: 'Asia' },
+  ],
+  slate: [
+    { code: 'UY', name: 'Uruguay', tier: 'slate', flag: '🇺🇾', currency: 'UYU', region: 'South America' },
+    { code: 'PA', name: 'Panama', tier: 'slate', flag: '🇵🇦', currency: 'PAB', region: 'Central America' },
+    { code: 'CR', name: 'Costa Rica', tier: 'slate', flag: '🇨🇷', currency: 'CRC', region: 'Central America' },
+  ],
+} as const;
+
+// ─── HELPERS ──────────────────────────────────────────────────────────
+
+/** Get all 57 countries as a flat array */
+export function getAllCountries(): CountryEntry[] {
+  return Object.values(HC_COUNTRY_TIERS).flat();
+}
+
+/** Look up a country by ISO code */
+export function getCountryByCode(code: string): CountryEntry | undefined {
+  return getAllCountries().find(c => c.code === code.toUpperCase());
+}
+
+/** Get all countries in a specific tier */
+export function getCountriesByTier(tier: CountryTier): CountryEntry[] {
+  return HC_COUNTRY_TIERS[tier] ?? [];
+}
+
+/** Get the tier for a country code */
+export function getTierForCountry(code: string): CountryTier | undefined {
+  return getCountryByCode(code)?.tier;
+}
+
+/** Check if a country is in the HC ecosystem */
+export function isHCCountry(code: string): boolean {
+  return !!getCountryByCode(code);
+}
+
+/** Get country count per tier */
+export function getTierCounts(): Record<CountryTier, number> {
+  return {
+    gold: HC_COUNTRY_TIERS.gold.length,
+    blue: HC_COUNTRY_TIERS.blue.length,
+    silver: HC_COUNTRY_TIERS.silver.length,
+    slate: HC_COUNTRY_TIERS.slate.length,
+  };
+}

--- a/core/hc-route/index.ts
+++ b/core/hc-route/index.ts
@@ -1,0 +1,17 @@
+/**
+ * HC Route — Permit-Aware Oversize Load Routing Engine
+ * 
+ * The only GPS routing engine purpose-built for oversized loads.
+ * Permit-aware, constraint-aware, crowd-sourced.
+ * 
+ * Built on:
+ * - GraphHopper (Apache 2.0) — routing engine with custom vehicle profiles
+ * - FHWA National Bridge Inventory — 620,000+ bridges with clearance data
+ * - OpenStreetMap — maxheight, maxweight, maxwidth, hgv tags
+ * - HC Waze — crowd-sourced hazard reporting from HC drivers
+ * - Waze Connected Citizens Program — free real-time incident data
+ */
+
+export * from './types';
+export * from './country-tiers';
+export * from './revenue-rails';

--- a/core/hc-route/revenue-rails.ts
+++ b/core/hc-route/revenue-rails.ts
@@ -1,0 +1,122 @@
+/**
+ * HC Revenue Rails — 8 Rails, No Money Leaves
+ * 
+ * Every dollar in the freight ecosystem flows through Haul Command.
+ * Each revenue rail maps to one or more HC Divisions.
+ */
+
+export interface RevenueRail {
+  id: string;
+  name: string;
+  description: string;
+  model: string;           // Pricing model (per-transaction, subscription, etc.)
+  division: string;        // Primary HC Division
+  alphabetAnalog: string;  // What Google/Alphabet equivalent this maps to
+  status: 'active' | 'beta' | 'planned';
+  projectedRevenue?: string; // At scale
+}
+
+export const HC_REVENUE_RAILS: RevenueRail[] = [
+  {
+    id: 'load-fees',
+    name: 'Load Fees',
+    description: 'Per-transaction fee on every load matched through HC Load Marketplace. Operators and brokers pay a platform fee on successful matches.',
+    model: 'Per-transaction (% of load value)',
+    division: 'hc-load-marketplace',
+    alphabetAnalog: 'Google Search revenue (ads on search results)',
+    status: 'active',
+    projectedRevenue: '$2-5M/yr at 10K loads/month',
+  },
+  {
+    id: 'track-subscriptions',
+    name: 'HC Track Subscriptions',
+    description: 'Per-device monthly subscription for GPS tracking, fleet visibility, and HC Route oversize routing navigation.',
+    model: 'Subscription (per device/month)',
+    division: 'hc-track',
+    alphabetAnalog: 'Google Maps Platform API pricing',
+    status: 'planned',
+    projectedRevenue: '$190K/mo at 2K operators × 5 devices × $19/mo',
+  },
+  {
+    id: 'adgrid-revenue',
+    name: 'AdGrid Revenue',
+    description: 'CPC/CPM advertising from vendors (tire shops, insurance, fuel, parts) targeting operators on the HC platform.',
+    model: 'CPC ($0.50-$5.00) / CPM ($10-$50)',
+    division: 'hc-adgrid',
+    alphabetAnalog: 'Google Ads',
+    status: 'active',
+    projectedRevenue: '$500K-$2M/yr at scale',
+  },
+  {
+    id: 'marketplace-commissions',
+    name: 'Marketplace Commissions',
+    description: '30% commission on every extension, integration, and tool sold through the HC Marketplace App Store.',
+    model: 'Commission (30% of sale)',
+    division: 'hc-marketplace',
+    alphabetAnalog: 'Google Play Store 30% cut',
+    status: 'planned',
+    projectedRevenue: '$100K-$500K/yr depending on developer ecosystem',
+  },
+  {
+    id: 'api-access-fees',
+    name: 'API Access Fees',
+    description: 'Tiered API access for third-party developers building on HC infrastructure. Free tier, Pro tier, Enterprise tier.',
+    model: 'Tiered subscription + usage-based',
+    division: 'hc-developer-platform',
+    alphabetAnalog: 'Google Cloud Platform',
+    status: 'beta',
+    projectedRevenue: '$50K-$200K/yr',
+  },
+  {
+    id: 'capital-interest',
+    name: 'HC Capital Interest',
+    description: 'Interest earned on financing deployed to operators. Equipment loans, factoring, working capital advances.',
+    model: 'Interest (APR on deployed capital)',
+    division: 'hc-capital',
+    alphabetAnalog: 'Google Ventures / GV returns',
+    status: 'planned',
+    projectedRevenue: 'Depends on capital deployed',
+  },
+  {
+    id: 'data-intelligence',
+    name: 'Data & Intelligence Products',
+    description: 'Enterprise data products: rate benchmarks, demand forecasting, safety scoring, route optimization models.',
+    model: 'Enterprise subscription',
+    division: 'hc-intelligence',
+    alphabetAnalog: 'DeepMind / Google AI services',
+    status: 'planned',
+    projectedRevenue: '$200K-$1M/yr for enterprise clients',
+  },
+  {
+    id: 'partner-licensing',
+    name: 'Partner Licensing',
+    description: 'White-label licensing and reseller agreements. Partners pay to rebrand and resell HC technology in their markets.',
+    model: 'Licensing fee + revenue share',
+    division: 'hc-developer-platform',
+    alphabetAnalog: 'Google Cloud Partner program',
+    status: 'planned',
+    projectedRevenue: '$100K-$500K/yr per partner',
+  },
+];
+
+// ─── HELPERS ──────────────────────────────────────────────────────────
+
+/** Get total number of revenue rails */
+export function getTotalRails(): number {
+  return HC_REVENUE_RAILS.length;
+}
+
+/** Get active revenue rails */
+export function getActiveRails(): RevenueRail[] {
+  return HC_REVENUE_RAILS.filter(r => r.status === 'active');
+}
+
+/** Get rails by division */
+export function getRailsByDivision(divisionId: string): RevenueRail[] {
+  return HC_REVENUE_RAILS.filter(r => r.division === divisionId);
+}
+
+/** Get rails by status */
+export function getRailsByStatus(status: RevenueRail['status']): RevenueRail[] {
+  return HC_REVENUE_RAILS.filter(r => r.status === status);
+}

--- a/core/hc-route/types.ts
+++ b/core/hc-route/types.ts
@@ -1,0 +1,242 @@
+/**
+ * HC Route — Type Definitions
+ * 
+ * Complete TypeScript types for the HC Route oversize load routing engine.
+ * Covers: vehicle profiles, road restrictions, hazard reports, permit routes.
+ */
+
+// ─── RESTRICTION TYPES ────────────────────────────────────────────────
+
+export type RestrictionType =
+  | 'bridge_height'
+  | 'bridge_weight'
+  | 'road_width'
+  | 'road_weight'
+  | 'turn_radius'
+  | 'school_zone'
+  | 'residential'
+  | 'time_restricted'
+  | 'seasonal'
+  | 'construction'
+  | 'utility_line'
+  | 'no_oversize'
+  | 'no_hazmat'
+  | 'grade'
+  | 'tunnel';
+
+export type RestrictionSource =
+  | 'nbi'            // FHWA National Bridge Inventory
+  | 'osm'            // OpenStreetMap
+  | 'state_dot'      // State DOT
+  | 'crowd_sourced'  // Driver reports
+  | 'lidar'          // LiDAR measurement
+  | 'manual';        // Manual entry
+
+export interface RoadRestriction {
+  id: string;
+  lat: number;
+  lng: number;
+  osmWayId?: number;
+  roadName?: string;
+  stateCode?: string;
+  county?: string;
+  restrictionType: RestrictionType;
+  maxHeightFt?: number;
+  maxWidthFt?: number;
+  maxWeightLbs?: number;
+  maxLengthFt?: number;
+  maxAxleWeightLbs?: number;
+  minTurnRadiusFt?: number;
+  activeDays?: string[];
+  activeStartTime?: string;
+  activeEndTime?: string;
+  seasonalStart?: string;
+  seasonalEnd?: string;
+  source: RestrictionSource;
+  confidenceScore: number; // 0.0 to 1.0
+  verified: boolean;
+  verifiedBy?: string;
+  verifiedAt?: string;
+  notes?: string;
+  photoUrls?: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+// ─── VEHICLE PROFILE TYPES ────────────────────────────────────────────
+
+export type VehicleType =
+  | 'mobile_home'
+  | 'modular_building'
+  | 'heavy_equipment'
+  | 'wind_turbine_blade'
+  | 'transformer'
+  | 'construction_beam'
+  | 'military_vehicle'
+  | 'crane'
+  | 'house_move'
+  | 'custom';
+
+export interface VehicleProfile {
+  id: string;
+  operatorId: string;
+  profileName: string;
+  vehicleType: VehicleType;
+  totalHeightFt: number;
+  totalWidthFt: number;
+  totalLengthFt: number;
+  grossWeightLbs: number;
+  numAxles: number;
+  axleWeightLbs?: number;
+  minTurnRadiusFt?: number;
+  heightBufferFt: number;  // Safety margin above height
+  widthBufferFt: number;   // Safety margin beyond width
+  requiresEscort: boolean;
+  requiresPilotCar: boolean;
+  requiresPoliceEscort: boolean;
+  requiresUtilityNotification: boolean;
+  hazmat: boolean;
+  isTemplate: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// ─── PERMIT ROUTE TYPES ───────────────────────────────────────────────
+
+export type PermitType = 'single_trip' | 'annual' | 'multi_trip' | 'superload';
+
+export interface PermitRouteConflict {
+  type: RestrictionType;
+  location: { lat: number; lng: number };
+  detail: string;
+  severity: 'warning' | 'critical';
+}
+
+export interface PermitRouteWaypoint {
+  lat: number;
+  lng: number;
+  instruction: string;
+  roadName: string;
+  sequence: number;
+}
+
+export interface PermitRoute {
+  id: string;
+  operatorId: string;
+  loadId?: string;
+  vehicleProfileId: string;
+  permitNumber: string;
+  issuingState: string;
+  permitType: PermitType;
+  permittedHeightFt?: number;
+  permittedWidthFt?: number;
+  permittedLengthFt?: number;
+  permittedWeightLbs?: number;
+  originAddress: string;
+  originLat: number;
+  originLng: number;
+  destinationAddress: string;
+  destinationLat: number;
+  destinationLng: number;
+  waypoints: PermitRouteWaypoint[];
+  routeValidated: boolean;
+  restrictionsChecked: boolean;
+  conflictCount: number;
+  conflicts: PermitRouteConflict[];
+  travelTimeStart?: string;
+  travelTimeEnd?: string;
+  noTravelDays?: string[];
+  noTravelDates?: string[];
+  maxSpeedMph?: number;
+  permitPdfUrl?: string;
+  permitRawText?: string;
+  validFrom: string;
+  validUntil: string;
+  createdAt: string;
+}
+
+// ─── HAZARD REPORT TYPES ──────────────────────────────────────────────
+
+export type HazardType =
+  // Oversize-specific
+  | 'low_bridge'
+  | 'low_utility_line'
+  | 'narrow_road'
+  | 'tight_turn'
+  | 'soft_shoulder'
+  | 'steep_grade'
+  | 'low_tree_branches'
+  | 'construction_overhead'
+  // General (Waze-style)
+  | 'construction'
+  | 'road_closure'
+  | 'lane_closure'
+  | 'accident'
+  | 'police'
+  | 'road_damage'
+  | 'flooding'
+  | 'weather'
+  | 'school_zone_active'
+  | 'weight_station_open'
+  // Positive
+  | 'good_route'
+  | 'clearance_verified';
+
+export type HazardSeverity = 'low' | 'medium' | 'high' | 'critical';
+
+export interface HazardReport {
+  id: string;
+  reporterId: string;
+  operatorId?: string;
+  lat: number;
+  lng: number;
+  roadName?: string;
+  direction?: string;
+  hazardType: HazardType;
+  description?: string;
+  measuredHeightFt?: number;
+  measuredWidthFt?: number;
+  photoUrls?: string[];
+  severity: HazardSeverity;
+  isActive: boolean;
+  expiresAt?: string;
+  confirmations: number;
+  denials: number;
+  confidenceScore: number;
+  reportedAt: string;
+  lastConfirmedAt?: string;
+}
+
+// ─── ROUTING ENGINE TYPES ─────────────────────────────────────────────
+
+export interface RouteRequest {
+  origin: { lat: number; lng: number };
+  destination: { lat: number; lng: number };
+  vehicleProfile: VehicleProfile;
+  permitRoute?: PermitRoute;  // If following a specific permit route
+  avoidHazards: boolean;
+  includeAlternatives: boolean;
+}
+
+export type AlertLevel = 'stop' | 'caution' | 'slow' | 'info' | 'verified';
+
+export interface RouteAlert {
+  level: AlertLevel;
+  message: string;
+  location: { lat: number; lng: number };
+  distanceAheadMiles: number;
+  restriction?: RoadRestriction;
+  hazard?: HazardReport;
+}
+
+export interface RouteResult {
+  success: boolean;
+  distance: number;           // miles
+  duration: number;           // minutes
+  geometry: any;              // GeoJSON LineString
+  alerts: RouteAlert[];
+  restrictionsAvoided: number;
+  hazardsOnRoute: number;
+  permitCompliant: boolean;
+  alternativeRoutes?: RouteResult[];
+}

--- a/supabase/migrations/20260321_hc_route_schema.sql
+++ b/supabase/migrations/20260321_hc_route_schema.sql
@@ -1,0 +1,262 @@
+-- ============================================================
+-- HC Route — Database Schema
+-- Permit-Aware Oversize Load Routing Engine
+-- ============================================================
+-- This migration creates the core tables for HC Route:
+-- 1. road_restrictions — Physical constraints (bridges, roads, tunnels)
+-- 2. vehicle_profiles — Load/vehicle dimension profiles
+-- 3. permit_routes — Digitized permit routes with GPS waypoints
+-- 4. hazard_reports — Crowd-sourced hazard reports (HC Waze)
+-- ============================================================
+
+-- Enable PostGIS if not already enabled
+CREATE EXTENSION IF NOT EXISTS postgis;
+
+-- ─── 1. ROAD RESTRICTIONS ─────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS road_restrictions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  
+  -- Location
+  lat DOUBLE PRECISION NOT NULL,
+  lng DOUBLE PRECISION NOT NULL,
+  osm_way_id BIGINT,
+  road_name TEXT,
+  state_code CHAR(2),
+  county TEXT,
+  
+  -- Restriction Type
+  restriction_type TEXT NOT NULL CHECK (restriction_type IN (
+    'bridge_height', 'bridge_weight', 'road_width', 'road_weight',
+    'turn_radius', 'school_zone', 'residential', 'time_restricted',
+    'seasonal', 'construction', 'utility_line', 'no_oversize',
+    'no_hazmat', 'grade', 'tunnel'
+  )),
+  
+  -- Restriction Values
+  max_height_ft REAL,
+  max_width_ft REAL,
+  max_weight_lbs INTEGER,
+  max_length_ft REAL,
+  max_axle_weight_lbs INTEGER,
+  min_turn_radius_ft REAL,
+  
+  -- Time-based restrictions
+  active_days TEXT[],
+  active_start_time TIME,
+  active_end_time TIME,
+  seasonal_start DATE,
+  seasonal_end DATE,
+  
+  -- Source & Confidence
+  source TEXT NOT NULL CHECK (source IN (
+    'nbi', 'osm', 'state_dot', 'crowd_sourced', 'lidar', 'manual'
+  )),
+  confidence_score REAL DEFAULT 0.5 CHECK (confidence_score >= 0 AND confidence_score <= 1),
+  verified BOOLEAN DEFAULT false,
+  verified_by UUID,
+  verified_at TIMESTAMPTZ,
+  
+  -- Metadata
+  notes TEXT,
+  photo_urls TEXT[],
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Spatial index for fast geo queries
+CREATE INDEX IF NOT EXISTS idx_restrictions_geo 
+  ON road_restrictions USING GIST (
+    ST_SetSRID(ST_MakePoint(lng, lat), 4326)
+  );
+
+CREATE INDEX IF NOT EXISTS idx_restrictions_type ON road_restrictions(restriction_type);
+CREATE INDEX IF NOT EXISTS idx_restrictions_state ON road_restrictions(state_code);
+CREATE INDEX IF NOT EXISTS idx_restrictions_source ON road_restrictions(source);
+
+-- ─── 2. VEHICLE PROFILES ──────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS vehicle_profiles (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  operator_id UUID,
+  
+  -- Profile info
+  profile_name TEXT NOT NULL,
+  vehicle_type TEXT NOT NULL CHECK (vehicle_type IN (
+    'mobile_home', 'modular_building', 'heavy_equipment',
+    'wind_turbine_blade', 'transformer', 'construction_beam',
+    'military_vehicle', 'crane', 'house_move', 'custom'
+  )),
+  
+  -- Dimensions (imperial for US)
+  total_height_ft REAL NOT NULL,
+  total_width_ft REAL NOT NULL,
+  total_length_ft REAL NOT NULL,
+  gross_weight_lbs INTEGER NOT NULL,
+  num_axles INTEGER DEFAULT 5,
+  axle_weight_lbs INTEGER,
+  min_turn_radius_ft REAL,
+  
+  -- Safety margins
+  height_buffer_ft REAL DEFAULT 0.5,
+  width_buffer_ft REAL DEFAULT 1.0,
+  
+  -- Requirements
+  requires_escort BOOLEAN DEFAULT false,
+  requires_pilot_car BOOLEAN DEFAULT false,
+  requires_police_escort BOOLEAN DEFAULT false,
+  requires_utility_notification BOOLEAN DEFAULT false,
+  hazmat BOOLEAN DEFAULT false,
+  
+  -- Flags
+  is_template BOOLEAN DEFAULT false,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_vehicle_profiles_operator ON vehicle_profiles(operator_id);
+CREATE INDEX IF NOT EXISTS idx_vehicle_profiles_type ON vehicle_profiles(vehicle_type);
+CREATE INDEX IF NOT EXISTS idx_vehicle_profiles_template ON vehicle_profiles(is_template) WHERE is_template = true;
+
+-- ─── 3. PERMIT ROUTES ─────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS permit_routes (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  operator_id UUID,
+  load_id UUID,
+  vehicle_profile_id UUID REFERENCES vehicle_profiles(id),
+  
+  -- Permit info
+  permit_number TEXT NOT NULL,
+  issuing_state CHAR(2) NOT NULL,
+  permit_type TEXT CHECK (permit_type IN (
+    'single_trip', 'annual', 'multi_trip', 'superload'
+  )),
+  
+  -- Permitted dimensions
+  permitted_height_ft REAL,
+  permitted_width_ft REAL,
+  permitted_length_ft REAL,
+  permitted_weight_lbs INTEGER,
+  
+  -- Route endpoints
+  origin_address TEXT,
+  origin_lat DOUBLE PRECISION,
+  origin_lng DOUBLE PRECISION,
+  destination_address TEXT,
+  destination_lat DOUBLE PRECISION,
+  destination_lng DOUBLE PRECISION,
+  
+  -- Digitized route
+  route_geometry GEOMETRY(LineString, 4326),
+  waypoints JSONB,
+  
+  -- Validation
+  route_validated BOOLEAN DEFAULT false,
+  restrictions_checked BOOLEAN DEFAULT false,
+  conflict_count INTEGER DEFAULT 0,
+  conflicts JSONB,
+  
+  -- Travel restrictions from permit
+  travel_time_start TIME,
+  travel_time_end TIME,
+  no_travel_days TEXT[],
+  no_travel_dates DATE[],
+  max_speed_mph INTEGER,
+  
+  -- Permit document
+  permit_pdf_url TEXT,
+  permit_raw_text TEXT,
+  
+  -- Validity
+  valid_from DATE,
+  valid_until DATE,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_permit_routes_geo 
+  ON permit_routes USING GIST (route_geometry);
+CREATE INDEX IF NOT EXISTS idx_permit_routes_operator ON permit_routes(operator_id);
+CREATE INDEX IF NOT EXISTS idx_permit_routes_state ON permit_routes(issuing_state);
+CREATE INDEX IF NOT EXISTS idx_permit_routes_valid 
+  ON permit_routes(valid_from, valid_until) WHERE valid_until >= CURRENT_DATE;
+
+-- ─── 4. HAZARD REPORTS (HC WAZE) ──────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS hazard_reports (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  reporter_id UUID,
+  operator_id UUID,
+  
+  -- Location
+  lat DOUBLE PRECISION NOT NULL,
+  lng DOUBLE PRECISION NOT NULL,
+  road_name TEXT,
+  direction TEXT,
+  
+  -- Hazard type
+  hazard_type TEXT NOT NULL CHECK (hazard_type IN (
+    -- Oversize-Specific
+    'low_bridge', 'low_utility_line', 'narrow_road', 'tight_turn',
+    'soft_shoulder', 'steep_grade', 'low_tree_branches', 'construction_overhead',
+    -- General (Waze-style)
+    'construction', 'road_closure', 'lane_closure', 'accident', 'police',
+    'road_damage', 'flooding', 'weather', 'school_zone_active', 'weight_station_open',
+    -- Positive Reports
+    'good_route', 'clearance_verified'
+  )),
+  
+  -- Details
+  description TEXT,
+  measured_height_ft REAL,
+  measured_width_ft REAL,
+  photo_urls TEXT[],
+  
+  -- Severity & Status
+  severity TEXT DEFAULT 'medium' CHECK (severity IN ('low', 'medium', 'high', 'critical')),
+  is_active BOOLEAN DEFAULT true,
+  expires_at TIMESTAMPTZ,
+  
+  -- Community validation
+  confirmations INTEGER DEFAULT 0,
+  denials INTEGER DEFAULT 0,
+  confidence_score REAL DEFAULT 0.5 CHECK (confidence_score >= 0 AND confidence_score <= 1),
+  
+  -- Timestamps
+  reported_at TIMESTAMPTZ DEFAULT NOW(),
+  last_confirmed_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_hazards_geo 
+  ON hazard_reports USING GIST (
+    ST_SetSRID(ST_MakePoint(lng, lat), 4326)
+  );
+CREATE INDEX IF NOT EXISTS idx_hazards_active 
+  ON hazard_reports(is_active, hazard_type) WHERE is_active = true;
+CREATE INDEX IF NOT EXISTS idx_hazards_reporter ON hazard_reports(reporter_id);
+CREATE INDEX IF NOT EXISTS idx_hazards_severity 
+  ON hazard_reports(severity) WHERE is_active = true;
+
+-- ─── 5. SEED: VEHICLE PROFILE TEMPLATES ───────────────────────────────
+
+INSERT INTO vehicle_profiles (profile_name, vehicle_type, total_height_ft, total_width_ft, total_length_ft, gross_weight_lbs, num_axles, requires_escort, requires_pilot_car, is_template)
+VALUES
+  ('14-Wide Single-Wide Mobile Home', 'mobile_home', 14.5, 14.0, 76.0, 28000, 3, true, true, true),
+  ('16-Wide Single-Wide Mobile Home', 'mobile_home', 14.5, 16.0, 76.0, 32000, 3, true, true, true),
+  ('Double-Wide Mobile Home (Half)', 'mobile_home', 14.5, 14.0, 60.0, 22000, 3, true, true, true),
+  ('CAT 390F Excavator', 'heavy_equipment', 13.0, 12.5, 55.0, 95000, 5, true, false, true),
+  ('D8T Dozer', 'heavy_equipment', 12.0, 14.0, 50.0, 82000, 5, true, false, true),
+  ('Liebherr LTM 1300 Crane', 'crane', 13.5, 10.0, 65.0, 120000, 7, true, true, true),
+  ('Wind Turbine Blade (60m)', 'wind_turbine_blade', 14.0, 12.0, 200.0, 45000, 5, true, true, true),
+  ('Modular Building Section', 'modular_building', 16.0, 16.0, 70.0, 50000, 5, true, true, true),
+  ('Large Transformer', 'transformer', 14.0, 14.0, 45.0, 200000, 9, true, true, true),
+  ('House Move (Full Structure)', 'house_move', 25.0, 30.0, 60.0, 80000, 6, true, true, true)
+ON CONFLICT DO NOTHING;
+
+-- ─── DONE ─────────────────────────────────────────────────────────────
+-- HC Route schema ready. Next steps:
+-- 1. Import FHWA NBI data (620K bridges) → road_restrictions
+-- 2. Import OSM maxheight/maxweight tags → road_restrictions  
+-- 3. Deploy GraphHopper with custom oversize vehicle profile
+-- 4. Build permit PDF → OCR → route digitization pipeline
+-- 5. Build HC Waze hazard reporting in driver app


### PR DESCRIPTION
## 🏗️ HC Alphabet Structure + HC Route + 57-Country Tiers + 8 Revenue Rails

### The Mission
Don't integrate with the ecosystem — **become the ecosystem**. Own the rails, own the data, own the revenue. Start as the default (Uber model), scale as the parent company (Alphabet model).

---

### What's Added

#### 1. `core/hc-platform-registry.ts` — Unified Platform Registry
The single source of truth for the entire Haul Command Alphabet Structure:
- **8 HC Divisions** mapped to their Google/Alphabet analogs
- **HC Route** as a new 9th division (oversize load routing — nobody else has this)
- Platform constants and principles

| HC Division | Alphabet Analog | Revenue Rail |
|-------------|----------------|-------------|
| HC Track | Google Maps | Per-device subscriptions |
| HC Load Marketplace | Google Search | Per-transaction load fees |
| HC AdGrid | Google Ads | CPC/CPM advertising |
| HC Pay | Google Pay | Transaction processing |
| HC Intelligence | DeepMind | Enterprise data products |
| HC Developer Platform | Google Cloud | Tiered API access |
| HC Marketplace | Google Play Store | 30% commission |
| HC Capital | Google Ventures | Interest on financing |
| **HC Route** | **Waze + PC*Miler killer** | **Routing subscriptions** |

#### 2. `core/hc-route/` — HC Route Oversize Load Routing Engine
The only GPS routing engine purpose-built for oversized loads:
- **`types.ts`** — Complete TypeScript types for vehicle profiles, road restrictions, hazard reports, permit routes, routing engine
- **`country-tiers.ts`** — Canonical 57-country tier system (Gold/Blue/Silver/Slate) with all helpers
- **`revenue-rails.ts`** — 8 revenue rail definitions with pricing models and Alphabet mappings
- **`index.ts`** — Clean re-exports

##### Tech Stack
- **GraphHopper** (Apache 2.0) — routing engine with custom oversize vehicle profiles
- **FHWA NBI** — 620,000+ bridges with height/weight/clearance data (free)
- **OpenStreetMap** — maxheight, maxweight, hgv tags (free)
- **HC Waze** — crowd-sourced hazard reporting (built-in)
- **PostGIS** — spatial indexing on Supabase PostgreSQL

#### 3. `supabase/migrations/20260321_hc_route_schema.sql` — Database Schema
Complete Supabase migration with PostGIS:
- `road_restrictions` — Physical constraints (bridges, tunnels, roads) with spatial indexes
- `vehicle_profiles` — Load/vehicle dimension profiles with 10 pre-seeded templates
- `permit_routes` — Digitized permit routes (PDF → GPS waypoints)
- `hazard_reports` — Crowd-sourced hazard reports (HC Waze)

### 57 Countries by Tier
- 🥇 **Gold (10)**: US, CA, AU, GB, NZ, ZA, DE, NL, AE, BR
- 🔵 **Blue (18)**: IE, SE, NO, DK, FI, BE, AT, CH, ES, FR, IT, PT, SA, QA, MX, IN, ID, TH
- 🥈 **Silver (26)**: PL, CZ, SK, HU, SI, EE, LV, LT, HR, RO, BG, GR, TR, KW, OM, BH, SG, MY, JP, KR, CL, AR, CO, PE, VN, PH
- 🪨 **Slate (3)**: UY, PA, CR

### 8 Revenue Rails
1. Load fees (per transaction)
2. HC Track subscriptions (per device)
3. AdGrid revenue (CPC/CPM)
4. Marketplace commissions (30%)
5. API access fees (tiered)
6. HC Capital interest (financing)
7. Data/intelligence products (enterprise)
8. Partner licensing (resellers)

### Redundancy Audit ✅
- Checked `lib/countries.ts` — new country-tiers.ts is the canonical upgrade
- No existing tracking/routing modules found — HC Route is net-new
- Revenue rails consolidated from scattered YAML specs into single TypeScript module
- No downgrades — everything is additive