### PR TITLE
fix: resolve ad_boosts.operator_id and directory_listings.lat column errors

### DIFF
--- a/haul-command-hub/src/app/api/cron/boost-expiry/route.ts
+++ b/haul-command-hub/src/app/api/cron/boost-expiry/route.ts
@@ -1,9 +1,9 @@
 /**
  * GET /api/cron/boost-expiry
  *
- * Cron job to expire ad boosts that have passed their end_date.
+ * Cron job to expire ad boosts that have passed their expires_at.
  * Runs every 6 hours via Vercel Cron.
- * Updates status from 'active' to 'expired' and cleans listing flags.
+ * Updates status from 'active' to 'expired'.
  */
 
 import { NextResponse } from 'next/server';
@@ -27,11 +27,13 @@ export async function GET(request: Request) {
     const sb = supabaseServer();
 
     // ── Step 1: Find expired ad_boosts ──────────────────────────────────
+    // Schema: id, profile_id, duration_days, amount_cents, stripe_session_id,
+    //         status, starts_at, expires_at, created_at
     const { data: expired, error: findErr } = await sb
       .from('ad_boosts')
-      .select('id, operator_id, listing_id')
+      .select('id, profile_id')
       .eq('status', 'active')
-      .lt('end_date', now);
+      .lt('expires_at', now);
 
     if (findErr) {
       console.error('[Boost Expiry] Query error on ad_boosts:', findErr.message, findErr.details);
@@ -53,23 +55,9 @@ export async function GET(request: Request) {
       }
 
       expiredBoostCount = ids.length;
-
-      // ── Step 3: Downgrade listing flags (non-fatal) ────────────────────
-      const listingIds = [...new Set(expired.map(b => b.listing_id).filter(Boolean))];
-      if (listingIds.length > 0) {
-        const { error: listingErr } = await sb
-          .from('listings')
-          .update({ is_boosted: false, boost_tier: null })
-          .in('id', listingIds);
-
-        if (listingErr) {
-          // Non-fatal — log but continue
-          console.warn('[Boost Expiry] Listing downgrade warning:', listingErr.message);
-        }
-      }
     }
 
-    // ── Step 4: Also expire AdGrid campaigns ─────────────────────────────
+    // ── Step 3: Also expire AdGrid campaigns ─────────────────────────────
     const { data: expiredCampaigns, error: campErr } = await sb
       .from('adgrid_campaigns')
       .select('id')
@@ -107,4 +95,3 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: 'Unexpected server error', details: message }, { status: 500 });
   }
 }
-

--- a/lib/seo/programmatic-data.ts
+++ b/lib/seo/programmatic-data.ts
@@ -45,9 +45,10 @@ export async function getCityData(country: string, state: string, citySlug: stri
     const supabase = supabaseServer();
     const cityName = citySlug.split('-').map(s => s.charAt(0).toUpperCase() + s.slice(1)).join(' ');
 
+    // DB schema uses `latitude` / `longitude`, not `lat` / `lng`
     const { data, error } = await supabase
         .from("directory_listings")
-        .select("city,lat,lng")
+        .select("city,latitude,longitude")
         .ilike("country_code", country)
         .ilike("region_code", state)
         .ilike("city", cityName)
@@ -79,8 +80,8 @@ export async function getCityData(country: string, state: string, citySlug: stri
         country,
         state,
         city: data.city ?? cityName,
-        lat: Number(data.lat ?? 0),
-        lng: Number(data.lng ?? 0),
+        lat: Number(data.latitude ?? 0),
+        lng: Number(data.longitude ?? 0),
         slug: citySlug,
         nearbyCities,
     };


### PR DESCRIPTION
## 🔧 Fix: Column mismatch errors in production

Resolves **5 production errors** from Vercel logs (past 24h):

### Bug 1: `ad_boosts.operator_id does not exist` (4 occurrences)

**File:** `haul-command-hub/src/app/api/cron/boost-expiry/route.ts`

The boost-expiry cron job queried columns that don't exist on the `ad_boosts` table:
| Code queries | Actual schema (`20260319_social_adgrid.sql`) |
|---|---|
| `operator_id` | `profile_id` |
| `listing_id` | *(does not exist)* |
| `end_date` | `expires_at` |

**Fix:** Changed `.select('id, operator_id, listing_id')` → `.select('id, profile_id')` and `.lt('end_date', now)` → `.lt('expires_at', now)`. Also removed the listing downgrade step since `listing_id` doesn't exist on this table.

### Bug 2: `directory_listings.lat does not exist` (1 occurrence)

**File:** `lib/seo/programmatic-data.ts`

The `getCityData()` function queried `lat`/`lng` but the actual `directory_listings` table uses `latitude`/`longitude`.

**Fix:** Changed `.select("city,lat,lng")` → `.select("city,latitude,longitude")` and updated the return mapping accordingly.

### Error Log References
- Endpoint: `/api/cron/boost-expiry` → 500 (4x in last 24h)
- Endpoint: `/near/odessa/pilot-car-within-50` → 404 (1x)