### PR TITLE
feat(training): SEO crown jewel rebuild — 7 modules in HTML, FAQ answers crawlable, Course+FAQ+Breadcrumb schema, country/state routes

### DIFF
--- a/app/training/[country]/[state]/page.tsx
+++ b/app/training/[country]/[state]/page.tsx
@@ -1,0 +1,147 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+interface Props {
+  params: Promise<{ country: string; state: string }>;
+}
+
+const MANDATORY_CERT_STATES = ['washington', 'arizona', 'colorado', 'florida', 'georgia', 'louisiana', 'north-carolina', 'oregon', 'south-carolina', 'tennessee', 'texas', 'virginia'];
+
+const gold = '#D4A844';
+
+function toTitle(slug: string) {
+  return slug.replace(/-/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { state, country } = await params;
+  const stateName = toTitle(state);
+  const countryName = toTitle(country);
+  const mandatory = country === 'united-states' && MANDATORY_CERT_STATES.includes(state);
+  return {
+    title: `Pilot Car Training in ${stateName} — ${mandatory ? 'Mandatory Certification' : 'HC Certified'} | Haul Command`,
+    description: `Pilot car and escort operator training for ${stateName}, ${countryName}. ${mandatory ? `${stateName} requires mandatory pilot car certification — HC Certified meets all state requirements.` : `HC Certified covers all escort requirements in ${stateName} and is accepted as an operator trust standard by brokers.`}`,
+    alternates: { canonical: `https://www.haulcommand.com/training/${country}/${state}` },
+  };
+}
+
+export default async function StateTrainingPage({ params }: Props) {
+  const { state, country } = await params;
+  const stateName = toTitle(state);
+  const countryName = toTitle(country);
+  const mandatory = country === 'united-states' && MANDATORY_CERT_STATES.includes(state);
+
+  const schema = {
+    '@context': 'https://schema.org',
+    '@type': 'WebPage',
+    name: `Pilot Car Training in ${stateName} | Haul Command`,
+    url: `https://www.haulcommand.com/training/${country}/${state}`,
+    breadcrumb: {
+      '@type': 'BreadcrumbList',
+      itemListElement: [
+        { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.haulcommand.com' },
+        { '@type': 'ListItem', position: 2, name: 'Training', item: 'https://www.haulcommand.com/training' },
+        { '@type': 'ListItem', position: 3, name: countryName, item: `https://www.haulcommand.com/training/${country}` },
+        { '@type': 'ListItem', position: 4, name: stateName, item: `https://www.haulcommand.com/training/${country}/${state}` },
+      ],
+    },
+  };
+
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }} />
+      <div style={{ minHeight: '100vh', background: '#07090d', color: '#e8e8e8' }}>
+        {/* Breadcrumb */}
+        <nav aria-label="Breadcrumb" style={{ borderBottom: '1px solid rgba(255,255,255,0.05)', padding: '12px 0' }}>
+          <div style={{ maxWidth: 1100, margin: '0 auto', padding: '0 20px', display: 'flex', gap: 6, fontSize: 11, color: '#6b7280', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.08em', flexWrap: 'wrap' }}>
+            <Link href="/" style={{ color: '#6b7280', textDecoration: 'none' }}>Home</Link>
+            <span>›</span>
+            <Link href="/training" style={{ color: '#6b7280', textDecoration: 'none' }}>Training</Link>
+            <span>›</span>
+            <Link href={`/training/${country}`} style={{ color: '#6b7280', textDecoration: 'none' }}>{countryName}</Link>
+            <span>›</span>
+            <span style={{ color: gold }}>{stateName}</span>
+          </div>
+        </nav>
+
+        {/* Hero */}
+        <section style={{ borderBottom: '1px solid rgba(255,255,255,0.06)', padding: 'clamp(2rem,5vw,3.5rem) 20px' }}>
+          <div style={{ maxWidth: 1100, margin: '0 auto' }}>
+            {mandatory && (
+              <div style={{ display: 'inline-flex', alignItems: 'center', gap: 6, padding: '4px 12px', background: 'rgba(239,68,68,0.1)', border: '1px solid rgba(239,68,68,0.25)', borderRadius: 20, marginBottom: 14 }}>
+                <span style={{ fontSize: 11, fontWeight: 700, color: '#f87171', textTransform: 'uppercase', letterSpacing: '0.1em' }}>⚠ Mandatory Certification State</span>
+              </div>
+            )}
+            <h1 style={{ margin: '0 0 12px', fontSize: 'clamp(1.8rem,4vw,2.6rem)', fontWeight: 900, color: '#f9fafb', lineHeight: 1.1 }}>
+              Pilot Car Training in {stateName}
+            </h1>
+            <p style={{ margin: '0 0 16px', fontSize: 15, color: '#9ca3af', lineHeight: 1.7, maxWidth: 640 }}>
+              {mandatory
+                ? `${stateName} is one of 12 US states that require mandatory pilot car certification. HC Certified meets or exceeds ${stateName} curriculum requirements and is accepted as an operator qualification baseline by brokers and carriers operating in this state.`
+                : `HC Certified provides the foundational knowledge for operating as a pilot car escort in ${stateName}. It is accepted by brokers and carriers as an operator trust and qualification standard.`
+              }
+            </p>
+            <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
+              <Link href="/training/pilot-car-fundamentals" style={{ display: 'inline-flex', alignItems: 'center', gap: 8, padding: '12px 24px', borderRadius: 12, background: `linear-gradient(135deg, ${gold}, #E4B872)`, color: '#000', fontSize: 14, fontWeight: 900, textDecoration: 'none' }}>
+                🎓 Start {stateName} Training
+              </Link>
+              <Link href="/escort-requirements" style={{ display: 'inline-flex', alignItems: 'center', gap: 8, padding: '12px 20px', borderRadius: 12, background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.1)', color: '#9ca3af', fontSize: 13, fontWeight: 700, textDecoration: 'none' }}>
+                📋 {stateName} Escort Rules
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        {/* State FAQ */}
+        <section style={{ padding: 'clamp(1.5rem,3vw,2.5rem) 20px', borderBottom: '1px solid rgba(255,255,255,0.05)' }}>
+          <div style={{ maxWidth: 820, margin: '0 auto' }}>
+            <h2 style={{ margin: '0 0 14px', fontSize: 18, fontWeight: 800, color: '#f9fafb' }}>{stateName} Pilot Car Training FAQ</h2>
+            {[
+              {
+                q: `Does ${stateName} require pilot car certification?`,
+                a: mandatory
+                  ? `Yes. ${stateName} is one of 12 US states with mandatory pilot car certification requirements. HC Certified meets or exceeds the ${stateName} state curriculum requirements.`
+                  : `${stateName} does not currently have a mandatory certification requirement, but many brokers and carriers require or strongly prefer HC Certified operators. It also qualifies you for cross-state moves into mandatory states.`,
+              },
+              {
+                q: `Does HC Certified work for ${stateName} operations?`,
+                a: `Yes. HC Certified is built on FMCSA and SC&RA Best Practices Guidelines, which meet or exceed the requirements for all mandatory certification states including ${stateName}. Brokers across ${stateName} use Haul Command to verify operator certification status.`,
+              },
+              {
+                q: `How do I find pilot car jobs in ${stateName}?`,
+                a: `Claim your free Haul Command listing and get HC Certified. Brokers searching for escort capacity in ${stateName} can find and verify your profile instantly.`,
+              },
+            ].map((item, i) => (
+              <details key={i} style={{ marginBottom: 10, borderRadius: 12, background: 'rgba(255,255,255,0.025)', border: '1px solid rgba(255,255,255,0.06)', overflow: 'hidden' }}>
+                <summary style={{ padding: '14px 16px', cursor: 'pointer', fontWeight: 700, fontSize: 14, listStyle: 'none', display: 'flex', alignItems: 'center', gap: 8, color: '#e5e7eb' }}>
+                  <span style={{ color: gold }}>+</span>{item.q}
+                </summary>
+                <p style={{ padding: '0 16px 14px', margin: 0, fontSize: 13, color: 'rgba(255,255,255,0.6)', lineHeight: 1.7, borderTop: '1px solid rgba(255,255,255,0.05)' }}>{item.a}</p>
+              </details>
+            ))}
+          </div>
+        </section>
+
+        {/* Related links */}
+        <section style={{ padding: 'clamp(1.5rem,2.5vw,2rem) 20px' }}>
+          <div style={{ maxWidth: 1100, margin: '0 auto', display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+            {[
+              ['All Training Modules', '/training'],
+              [`${countryName} Training`, `/training/${country}`],
+              ['Escort Requirements', '/escort-requirements'],
+              ['Find Operators', `/find/pilot-car-operator/${state}`],
+              ['Heavy Haul Glossary', '/glossary'],
+              ['Verify a Badge', '/training/verify'],
+              ['Claim Your Listing', '/claim'],
+              ['Rate Index', '/rates'],
+            ].map(([label, href]) => (
+              <Link key={href} href={href} style={{ padding: '6px 12px', borderRadius: 999, fontSize: 12, fontWeight: 600, background: 'rgba(255,255,255,0.03)', border: '1px solid rgba(255,255,255,0.07)', color: '#9ca3af', textDecoration: 'none' }}>
+                {label}
+              </Link>
+            ))}
+          </div>
+        </section>
+      </div>
+    </>
+  );
+}

--- a/app/training/[country]/page.tsx
+++ b/app/training/[country]/page.tsx
@@ -1,0 +1,171 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+interface Props {
+  params: Promise<{ country: string }>;
+}
+
+const COUNTRY_META: Record<string, { name: string; terminology: string[]; notes: string }> = {
+  'united-states': { name: 'United States', terminology: ['pilot car', 'escort vehicle', 'PEVO', 'overdimensional'], notes: '12 states require mandatory pilot car certification. HC Certified meets or exceeds all state curriculum requirements.' },
+  'canada': { name: 'Canada', terminology: ['pilot car', 'escort vehicle', 'EVO', 'oversize'], notes: 'Requirements vary by province. Alberta and BC have the highest activity. HC Certified accepted as a training baseline for broker trust.' },
+  'australia': { name: 'Australia', terminology: ['pilot vehicle', 'escort vehicle', 'over-dimensional', 'NHVR'], notes: 'NHVR governs heavy vehicle permits nationally. State-level escort requirements vary. HC Certified aligns with best practice guidelines.' },
+  'united-kingdom': { name: 'United Kingdom', terminology: ['attendant vehicle', 'wide load escort', 'abnormal load'], notes: 'STGO categories govern abnormal load movements. HC Certified provides operational baseline aligned with DfT guidance.' },
+  'uae': { name: 'UAE', terminology: ['escort vehicle', 'oversized transport', 'special transport permit'], notes: 'Permit requirements governed by RTA and individual emirate authorities. HC Certified recognized as international operator baseline.' },
+};
+
+const US_STATES = [
+  { name: 'Texas', slug: 'texas' }, { name: 'California', slug: 'california' },
+  { name: 'Florida', slug: 'florida' }, { name: 'Washington', slug: 'washington' },
+  { name: 'Arizona', slug: 'arizona' }, { name: 'Colorado', slug: 'colorado' },
+  { name: 'Georgia', slug: 'georgia' }, { name: 'Ohio', slug: 'ohio' },
+  { name: 'Louisiana', slug: 'louisiana' }, { name: 'Oregon', slug: 'oregon' },
+  { name: 'North Carolina', slug: 'north-carolina' }, { name: 'Pennsylvania', slug: 'pennsylvania' },
+  { name: 'Tennessee', slug: 'tennessee' }, { name: 'Michigan', slug: 'michigan' },
+  { name: 'Illinois', slug: 'illinois' },
+];
+
+const gold = '#D4A844';
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { country } = await params;
+  const meta = COUNTRY_META[country];
+  const name = meta?.name ?? country.replace(/-/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
+  return {
+    title: `Pilot Car & Escort Operator Training in ${name} | Haul Command`,
+    description: `Heavy haul pilot car and escort operator certification for ${name}. State-aware, locally relevant training with digital badge verification. HC Certified, AV-Ready, and Elite pathways.`,
+    alternates: { canonical: `https://www.haulcommand.com/training/${country}` },
+  };
+}
+
+export default async function CountryTrainingPage({ params }: Props) {
+  const { country } = await params;
+  const meta = COUNTRY_META[country];
+  const countryName = meta?.name ?? country.replace(/-/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
+  const isUS = country === 'united-states';
+
+  const schema = {
+    '@context': 'https://schema.org',
+    '@type': 'WebPage',
+    name: `Pilot Car Training in ${countryName} — Haul Command`,
+    url: `https://www.haulcommand.com/training/${country}`,
+    breadcrumb: {
+      '@type': 'BreadcrumbList',
+      itemListElement: [
+        { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.haulcommand.com' },
+        { '@type': 'ListItem', position: 2, name: 'Training', item: 'https://www.haulcommand.com/training' },
+        { '@type': 'ListItem', position: 3, name: countryName, item: `https://www.haulcommand.com/training/${country}` },
+      ],
+    },
+  };
+
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }} />
+      <div style={{ minHeight: '100vh', background: '#07090d', color: '#e8e8e8' }}>
+        {/* Breadcrumb */}
+        <nav aria-label="Breadcrumb" style={{ borderBottom: '1px solid rgba(255,255,255,0.05)', padding: '12px 0' }}>
+          <div style={{ maxWidth: 1100, margin: '0 auto', padding: '0 20px', display: 'flex', gap: 6, fontSize: 11, color: '#6b7280', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.08em' }}>
+            <Link href="/" style={{ color: '#6b7280', textDecoration: 'none' }}>Home</Link>
+            <span>›</span>
+            <Link href="/training" style={{ color: '#6b7280', textDecoration: 'none' }}>Training</Link>
+            <span>›</span>
+            <span style={{ color: gold }}>{countryName}</span>
+          </div>
+        </nav>
+
+        {/* Hero */}
+        <section style={{ borderBottom: '1px solid rgba(255,255,255,0.06)', padding: 'clamp(2rem,5vw,4rem) 20px' }}>
+          <div style={{ maxWidth: 1100, margin: '0 auto' }}>
+            <div style={{ display: 'inline-flex', alignItems: 'center', gap: 6, padding: '4px 12px', background: 'rgba(212,168,68,0.1)', border: '1px solid rgba(212,168,68,0.25)', borderRadius: 20, marginBottom: 14 }}>
+              <span style={{ fontSize: 11, fontWeight: 700, color: gold, textTransform: 'uppercase', letterSpacing: '0.1em' }}>Training · {countryName}</span>
+            </div>
+            <h1 style={{ margin: '0 0 12px', fontSize: 'clamp(1.8rem,4vw,2.8rem)', fontWeight: 900, color: '#f9fafb', lineHeight: 1.1 }}>
+              Pilot Car &amp; Escort Operator Training<br />
+              <span style={{ color: gold }}>in {countryName}</span>
+            </h1>
+            {meta?.notes && (
+              <p style={{ margin: '0 0 20px', fontSize: 15, color: '#9ca3af', lineHeight: 1.7, maxWidth: 640 }}>{meta.notes}</p>
+            )}
+            {meta?.terminology && (
+              <p style={{ margin: '0 0 24px', fontSize: 13, color: '#6b7280' }}>
+                Common terms in {countryName}: {meta.terminology.join(', ')}
+              </p>
+            )}
+            <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
+              <Link href="/training/pilot-car-fundamentals" style={{ display: 'inline-flex', alignItems: 'center', gap: 8, padding: '12px 24px', borderRadius: 12, background: `linear-gradient(135deg, ${gold}, #E4B872)`, color: '#000', fontSize: 14, fontWeight: 900, textDecoration: 'none' }}>
+                🎓 Start Free Training
+              </Link>
+              <Link href="/escort-requirements" style={{ display: 'inline-flex', alignItems: 'center', gap: 8, padding: '12px 20px', borderRadius: 12, background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.1)', color: '#9ca3af', fontSize: 13, fontWeight: 700, textDecoration: 'none' }}>
+                📋 {countryName} Requirements
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        {/* US states drill-down */}
+        {isUS && (
+          <section style={{ padding: 'clamp(1.5rem,3vw,2.5rem) 20px', borderBottom: '1px solid rgba(255,255,255,0.05)' }}>
+            <div style={{ maxWidth: 1100, margin: '0 auto' }}>
+              <h2 style={{ margin: '0 0 14px', fontSize: 18, fontWeight: 800, color: '#f9fafb' }}>Training by US State</h2>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+                {US_STATES.map(st => (
+                  <Link key={st.slug} href={`/training/united-states/${st.slug}`}
+                    style={{ padding: '7px 14px', borderRadius: 999, fontSize: 13, fontWeight: 600, background: 'rgba(212,168,68,0.07)', border: '1px solid rgba(212,168,68,0.2)', color: gold, textDecoration: 'none' }}>
+                    {st.name}
+                  </Link>
+                ))}
+                <Link href="/escort-requirements" style={{ padding: '7px 14px', borderRadius: 999, fontSize: 13, fontWeight: 700, background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.08)', color: '#9ca3af', textDecoration: 'none' }}>All 50 States →</Link>
+              </div>
+            </div>
+          </section>
+        )}
+
+        {/* Modules for this country */}
+        <section style={{ padding: 'clamp(1.5rem,3vw,2.5rem) 20px', borderBottom: '1px solid rgba(255,255,255,0.05)' }}>
+          <div style={{ maxWidth: 1100, margin: '0 auto' }}>
+            <h2 style={{ margin: '0 0 14px', fontSize: 18, fontWeight: 800, color: '#f9fafb' }}>Training Modules</h2>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+              {[
+                { slug: 'pilot-car-fundamentals', title: 'Pilot Car Fundamentals', desc: 'Safety, roles, equipment — the global baseline' },
+                { slug: 'route-survey-clearance-intelligence', title: 'Route Survey & Clearance Intelligence', desc: 'Heights, widths, obstacles, and hazard documentation' },
+                { slug: 'state-jurisdiction-compliance', title: 'State & Jurisdiction Compliance', desc: 'Permit rules, signage, escort formation requirements' },
+                { slug: 'communication-convoy-control', title: 'Communication, Convoy Control & Incident Response', desc: 'Radio discipline, emergencies, multi-vehicle coordination' },
+                { slug: 'specialized-vertical-operations', title: 'Specialized Vertical Operations', desc: 'Wind, superload, oilfield, port, military, aerospace' },
+              ].map(m => (
+                <Link key={m.slug} href={`/training/${m.slug}`} style={{ display: 'flex', gap: 12, alignItems: 'center', padding: '14px 16px', borderRadius: 10, background: 'rgba(255,255,255,0.025)', border: '1px solid rgba(255,255,255,0.06)', textDecoration: 'none' }}>
+                  <div style={{ flex: 1 }}>
+                    <div style={{ fontSize: 13, fontWeight: 700, color: '#e5e7eb', marginBottom: 2 }}>{m.title}</div>
+                    <div style={{ fontSize: 11, color: '#6b7280' }}>{m.desc}</div>
+                  </div>
+                  <span style={{ color: gold }}>→</span>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Related links */}
+        <section style={{ padding: 'clamp(1.5rem,3vw,2rem) 20px' }}>
+          <div style={{ maxWidth: 1100, margin: '0 auto' }}>
+            <p style={{ margin: '0 0 12px', fontSize: 12, fontWeight: 700, color: 'rgba(255,255,255,0.3)', textTransform: 'uppercase', letterSpacing: '0.08em' }}>Related</p>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+              {[
+                ['All Training Modules', '/training'],
+                ['Escort Requirements', '/escort-requirements'],
+                ['Heavy Haul Glossary', '/glossary'],
+                ['Find Operators', '/directory'],
+                ['Verify a Badge', '/training/verify'],
+                ['Corporate Training', '/training/corporate'],
+                ['All Countries', '/training/countries'],
+              ].map(([label, href]) => (
+                <Link key={href} href={href} style={{ padding: '6px 12px', borderRadius: 999, fontSize: 12, fontWeight: 600, background: 'rgba(255,255,255,0.03)', border: '1px solid rgba(255,255,255,0.07)', color: '#9ca3af', textDecoration: 'none' }}>
+                  {label}
+                </Link>
+              ))}
+            </div>
+          </div>
+        </section>
+      </div>
+    </>
+  );
+}

--- a/app/training/[slug]/page.tsx
+++ b/app/training/[slug]/page.tsx
@@ -1,16 +1,177 @@
 import type { Metadata } from 'next';
+import Link from 'next/link';
+import { MODULES } from '../page';
+import ModuleDetail from './_ModuleDetail';
 
 interface Props {
   params: Promise<{ slug: string }>;
 }
 
+export async function generateStaticParams() {
+  return MODULES.map(m => ({ slug: m.slug }));
+}
+
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { slug } = await params;
-  const title = slug.replace(/-/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
+  const mod = MODULES.find(m => m.slug === slug);
+  const title = mod?.title ?? slug.replace(/-/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
+  const desc = mod?.description ??
+    `Complete the ${title} module to earn your HC certification. Built on FMCSA and SC&RA Best Practices.`;
   return {
-    title: `${title} — HC Certified Training`,
-    description: `Complete the ${title} module to earn your HC certification. Built on FMCSA and SC&RA Best Practices.`,
+    title: `${title} — Pilot Car Training | Haul Command`,
+    description: desc,
+    alternates: { canonical: `https://www.haulcommand.com/training/${slug}` },
+    openGraph: {
+      title: `${title} | Haul Command Training`,
+      description: desc,
+      url: `https://www.haulcommand.com/training/${slug}`,
+    },
   };
 }
 
-export { default } from './_ModuleDetail';
+const TIER_COLOR: Record<string, string> = {
+  'HC Certified': '#A8A8A8',
+  'AV-Ready': '#F5A623',
+  'Elite': '#E5E4E2',
+};
+
+const gold = '#D4A844';
+
+export default async function ModulePage({ params }: Props) {
+  const { slug } = await params;
+  const mod = MODULES.find(m => m.slug === slug);
+
+  // Schema
+  const schema = mod ? {
+    '@context': 'https://schema.org',
+    '@type': 'Course',
+    name: mod.title,
+    description: mod.description,
+    provider: { '@type': 'Organization', name: 'Haul Command', url: 'https://www.haulcommand.com' },
+    url: `https://www.haulcommand.com/training/${mod.slug}`,
+    timeRequired: `PT${mod.duration.replace(' min', 'M')}`,
+    isAccessibleForFree: mod.isFree,
+    educationalLevel: mod.tier,
+    teaches: mod.outcomes,
+    breadcrumb: {
+      '@type': 'BreadcrumbList',
+      itemListElement: [
+        { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.haulcommand.com' },
+        { '@type': 'ListItem', position: 2, name: 'Training', item: 'https://www.haulcommand.com/training' },
+        { '@type': 'ListItem', position: 3, name: mod.title, item: `https://www.haulcommand.com/training/${mod.slug}` },
+      ],
+    },
+  } : null;
+
+  const tierColor = mod ? (TIER_COLOR[mod.tier] ?? gold) : gold;
+  const prevMod = mod ? MODULES[mod.slot - 2] : null;
+  const nextMod = mod ? MODULES[mod.slot] : null;
+
+  return (
+    <>
+      {schema && <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }} />}
+
+      {/* SSR breadcrumb — always crawlable */}
+      <nav aria-label="Breadcrumb" style={{ borderBottom: '1px solid rgba(255,255,255,0.05)', padding: '12px 0', background: '#07090d' }}>
+        <div style={{ maxWidth: 1100, margin: '0 auto', padding: '0 20px', display: 'flex', gap: 6, fontSize: 11, color: '#6b7280', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.08em' }}>
+          <Link href="/" style={{ color: '#6b7280', textDecoration: 'none' }}>Home</Link>
+          <span>›</span>
+          <Link href="/training" style={{ color: '#6b7280', textDecoration: 'none' }}>Training</Link>
+          <span>›</span>
+          <span style={{ color: gold }}>{mod?.title ?? slug}</span>
+        </div>
+      </nav>
+
+      {/* SSR hero — crawlable module intro */}
+      {mod && (
+        <header style={{ background: '#07090d', borderBottom: '1px solid rgba(255,255,255,0.06)', padding: 'clamp(1.5rem,4vw,3rem) 20px' }}>
+          <div style={{ maxWidth: 1100, margin: '0 auto' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 14, flexWrap: 'wrap' }}>
+              <span style={{ fontSize: 12, fontWeight: 700, background: `${tierColor}18`, color: tierColor, padding: '3px 10px', borderRadius: 20, textTransform: 'uppercase', letterSpacing: '0.06em' }}>
+                Module {mod.slot} · {mod.tier}
+              </span>
+              {mod.isFree && <span style={{ fontSize: 12, fontWeight: 700, background: 'rgba(34,197,94,0.12)', color: '#22C55E', padding: '3px 10px', borderRadius: 20 }}>FREE</span>}
+              <span style={{ fontSize: 12, color: '#6b7280' }}>⏱ {mod.duration}</span>
+            </div>
+
+            <h1 style={{ margin: '0 0 12px', fontSize: 'clamp(1.6rem,4vw,2.5rem)', fontWeight: 900, color: '#f9fafb', lineHeight: 1.1, letterSpacing: '-0.03em' }}>
+              {mod.title}
+            </h1>
+
+            <p style={{ margin: '0 0 20px', fontSize: 15, color: '#9ca3af', lineHeight: 1.7, maxWidth: 680 }}>
+              {mod.description}
+            </p>
+
+            {/* Outcomes — always in HTML */}
+            <div style={{ marginBottom: 20 }}>
+              <p style={{ margin: '0 0 10px', fontSize: 12, fontWeight: 700, color: 'rgba(255,255,255,0.4)', textTransform: 'uppercase', letterSpacing: '0.08em' }}>What you will learn</p>
+              <ul style={{ margin: 0, padding: 0, listStyle: 'none', display: 'flex', flexDirection: 'column', gap: 6 }}>
+                {mod.outcomes.map(o => (
+                  <li key={o} style={{ fontSize: 13, color: '#d1d5db', display: 'flex', gap: 8, alignItems: 'center' }}>
+                    <span style={{ color: tierColor }}>✓</span>{o}
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
+              <Link href={`/training/${mod.slug}#start`} style={{ display: 'inline-flex', alignItems: 'center', gap: 8, padding: '12px 24px', borderRadius: 12, background: `linear-gradient(135deg, ${gold}, #E4B872)`, color: '#000', fontSize: 14, fontWeight: 900, textDecoration: 'none' }}>
+                {mod.isFree ? '🎓 Start Free' : '🎓 Start Module'}
+              </Link>
+              <Link href="/training" style={{ display: 'inline-flex', alignItems: 'center', gap: 8, padding: '12px 20px', borderRadius: 12, background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.1)', color: '#9ca3af', fontSize: 13, fontWeight: 700, textDecoration: 'none' }}>
+                ← Back to All Modules
+              </Link>
+            </div>
+
+            {/* Audience note */}
+            <p style={{ marginTop: 14, fontSize: 12, color: '#6b7280' }}>👤 For: {mod.audience}</p>
+          </div>
+        </header>
+      )}
+
+      {/* Client-side interactive module content */}
+      <ModuleDetail />
+
+      {/* SSR prev/next navigation — crawlable */}
+      <nav aria-label="Module navigation" style={{ background: '#07090d', borderTop: '1px solid rgba(255,255,255,0.05)', padding: 'clamp(1.5rem,3vw,2.5rem) 20px' }}>
+        <div style={{ maxWidth: 1100, margin: '0 auto', display: 'flex', justifyContent: 'space-between', gap: 12, flexWrap: 'wrap' }}>
+          {prevMod ? (
+            <Link href={`/training/${prevMod.slug}`} style={{ display: 'flex', flexDirection: 'column', gap: 4, padding: '14px 18px', borderRadius: 12, background: 'rgba(255,255,255,0.025)', border: '1px solid rgba(255,255,255,0.07)', textDecoration: 'none', flex: 1, minWidth: 200 }}>
+              <span style={{ fontSize: 11, color: '#6b7280', fontWeight: 600 }}>← Previous</span>
+              <span style={{ fontSize: 13, fontWeight: 700, color: '#d1d5db' }}>{prevMod.title}</span>
+            </Link>
+          ) : <div />}
+          {nextMod ? (
+            <Link href={`/training/${nextMod.slug}`} style={{ display: 'flex', flexDirection: 'column', gap: 4, padding: '14px 18px', borderRadius: 12, background: 'rgba(255,255,255,0.025)', border: '1px solid rgba(255,255,255,0.07)', textDecoration: 'none', flex: 1, minWidth: 200, textAlign: 'right' }}>
+              <span style={{ fontSize: 11, color: '#6b7280', fontWeight: 600 }}>Next →</span>
+              <span style={{ fontSize: 13, fontWeight: 700, color: '#d1d5db' }}>{nextMod.title}</span>
+            </Link>
+          ) : (
+            <Link href="/training" style={{ display: 'flex', flexDirection: 'column', gap: 4, padding: '14px 18px', borderRadius: 12, background: 'rgba(212,168,68,0.08)', border: '1px solid rgba(212,168,68,0.2)', textDecoration: 'none', flex: 1, minWidth: 200, textAlign: 'right' }}>
+              <span style={{ fontSize: 11, color: '#6b7280', fontWeight: 600 }}>All done →</span>
+              <span style={{ fontSize: 13, fontWeight: 700, color: '#D4A844' }}>View All Modules &amp; Pricing</span>
+            </Link>
+          )}
+        </div>
+
+        {/* Related links from module page */}
+        <div style={{ maxWidth: 1100, margin: '20px auto 0', display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+          {[
+            ['All Modules', '/training'],
+            ['Escort Requirements', '/escort-requirements'],
+            ['Pilot Car Glossary', '/glossary'],
+            ['Find Operators', '/directory'],
+            ['Rate Index', '/rates'],
+            ['Corporate Training', '/training/corporate'],
+            ['Verify a Badge', '/training/verify'],
+            ['Claim Your Listing', '/claim'],
+          ].map(([label, href]) => (
+            <Link key={href} href={href} style={{ padding: '6px 12px', borderRadius: 999, fontSize: 12, fontWeight: 600, background: 'rgba(255,255,255,0.03)', border: '1px solid rgba(255,255,255,0.07)', color: '#9ca3af', textDecoration: 'none' }}>
+              {label}
+            </Link>
+          ))}
+        </div>
+      </nav>
+    </>
+  );
+}

--- a/app/training/countries/page.tsx
+++ b/app/training/countries/page.tsx
@@ -1,0 +1,114 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'Pilot Car Training by Country — 120 Countries | Haul Command',
+  description: 'Find pilot car and escort operator training for your country. State-aware, globally-ready certification pathways in 120 countries including USA, Canada, Australia, UK, UAE, and more.',
+  alternates: { canonical: 'https://www.haulcommand.com/training/countries' },
+};
+
+const COUNTRIES = [
+  { name: 'United States', slug: 'united-states', region: 'Americas' },
+  { name: 'Canada', slug: 'canada', region: 'Americas' },
+  { name: 'Mexico', slug: 'mexico', region: 'Americas' },
+  { name: 'Brazil', slug: 'brazil', region: 'Americas' },
+  { name: 'Australia', slug: 'australia', region: 'Asia-Pacific' },
+  { name: 'New Zealand', slug: 'new-zealand', region: 'Asia-Pacific' },
+  { name: 'United Kingdom', slug: 'united-kingdom', region: 'Europe' },
+  { name: 'Germany', slug: 'germany', region: 'Europe' },
+  { name: 'Netherlands', slug: 'netherlands', region: 'Europe' },
+  { name: 'France', slug: 'france', region: 'Europe' },
+  { name: 'Belgium', slug: 'belgium', region: 'Europe' },
+  { name: 'Sweden', slug: 'sweden', region: 'Europe' },
+  { name: 'Norway', slug: 'norway', region: 'Europe' },
+  { name: 'UAE', slug: 'uae', region: 'Middle East' },
+  { name: 'Saudi Arabia', slug: 'saudi-arabia', region: 'Middle East' },
+  { name: 'Qatar', slug: 'qatar', region: 'Middle East' },
+  { name: 'South Africa', slug: 'south-africa', region: 'Africa' },
+  { name: 'India', slug: 'india', region: 'Asia-Pacific' },
+  { name: 'Singapore', slug: 'singapore', region: 'Asia-Pacific' },
+  { name: 'Thailand', slug: 'thailand', region: 'Asia-Pacific' },
+];
+
+const gold = '#D4A844';
+
+const REGIONS = ['Americas', 'Europe', 'Asia-Pacific', 'Middle East', 'Africa'];
+
+export default function CountriesIndexPage() {
+  const schema = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.haulcommand.com' },
+      { '@type': 'ListItem', position: 2, name: 'Training', item: 'https://www.haulcommand.com/training' },
+      { '@type': 'ListItem', position: 3, name: 'All Countries', item: 'https://www.haulcommand.com/training/countries' },
+    ],
+  };
+
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }} />
+      <div style={{ minHeight: '100vh', background: '#07090d', color: '#e8e8e8' }}>
+        <nav aria-label="Breadcrumb" style={{ borderBottom: '1px solid rgba(255,255,255,0.05)', padding: '12px 0' }}>
+          <div style={{ maxWidth: 1100, margin: '0 auto', padding: '0 20px', display: 'flex', gap: 6, fontSize: 11, color: '#6b7280', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.08em' }}>
+            <Link href="/" style={{ color: '#6b7280', textDecoration: 'none' }}>Home</Link>
+            <span>›</span>
+            <Link href="/training" style={{ color: '#6b7280', textDecoration: 'none' }}>Training</Link>
+            <span>›</span>
+            <span style={{ color: gold }}>All Countries</span>
+          </div>
+        </nav>
+
+        <section style={{ padding: 'clamp(2rem,5vw,4rem) 20px', borderBottom: '1px solid rgba(255,255,255,0.06)' }}>
+          <div style={{ maxWidth: 1100, margin: '0 auto' }}>
+            <h1 style={{ margin: '0 0 12px', fontSize: 'clamp(1.8rem,4vw,2.8rem)', fontWeight: 900, color: '#f9fafb' }}>
+              Pilot Car Training by Country
+            </h1>
+            <p style={{ margin: '0 0 24px', fontSize: 15, color: '#9ca3af', lineHeight: 1.7, maxWidth: 620 }}>
+              Haul Command Training is available in 120 countries. Each country page includes localized requirements,
+              terminology, compliance notes, and relevant resources for operators in that market.
+            </p>
+            <Link href="/training/pilot-car-fundamentals" style={{ display: 'inline-flex', alignItems: 'center', gap: 8, padding: '12px 24px', borderRadius: 12, background: `linear-gradient(135deg, ${gold}, #E4B872)`, color: '#000', fontSize: 14, fontWeight: 900, textDecoration: 'none' }}>
+              🎓 Start Training — Free
+            </Link>
+          </div>
+        </section>
+
+        {REGIONS.map(region => {
+          const regionCountries = COUNTRIES.filter(c => c.region === region);
+          if (!regionCountries.length) return null;
+          return (
+            <section key={region} style={{ padding: 'clamp(1.5rem,3vw,2.5rem) 20px', borderBottom: '1px solid rgba(255,255,255,0.05)' }}>
+              <div style={{ maxWidth: 1100, margin: '0 auto' }}>
+                <h2 style={{ margin: '0 0 14px', fontSize: 16, fontWeight: 800, color: '#d1d5db' }}>{region}</h2>
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+                  {regionCountries.map(c => (
+                    <Link key={c.slug} href={`/training/${c.slug}`}
+                      style={{ padding: '8px 16px', borderRadius: 999, fontSize: 13, fontWeight: 600, background: 'rgba(212,168,68,0.07)', border: '1px solid rgba(212,168,68,0.2)', color: gold, textDecoration: 'none' }}>
+                      {c.name}
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            </section>
+          );
+        })}
+
+        <section style={{ padding: 'clamp(1.5rem,2.5vw,2rem) 20px' }}>
+          <div style={{ maxWidth: 1100, margin: '0 auto', display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+            {[
+              ['All Training Modules', '/training'],
+              ['Escort Requirements', '/escort-requirements'],
+              ['Find Operators', '/directory'],
+              ['Verify a Badge', '/training/verify'],
+            ].map(([label, href]) => (
+              <Link key={href} href={href} style={{ padding: '6px 12px', borderRadius: 999, fontSize: 12, fontWeight: 600, background: 'rgba(255,255,255,0.03)', border: '1px solid rgba(255,255,255,0.07)', color: '#9ca3af', textDecoration: 'none' }}>
+                {label}
+              </Link>
+            ))}
+          </div>
+        </section>
+      </div>
+    </>
+  );
+}

--- a/app/training/page.tsx
+++ b/app/training/page.tsx
@@ -1,170 +1,621 @@
-import { Metadata } from 'next'
+import type { Metadata } from 'next'
+import Link from 'next/link'
 import { createClient } from '@/lib/supabase/server'
 import { JsonLd } from '@/components/seo/JsonLd'
-import { AdGridSlot } from '@/components/home/AdGridSlot'
-import Link from 'next/link'
 
+export const revalidate = 3600
+
+// ─── METADATA ──────────────────────────────────────────────────────────────
 export const metadata: Metadata = {
-  title: 'HC Training Academy — Pilot Car & Heavy Haul Certifications | Haul Command',
-  description: 'The only global heavy haul training and certification platform. Free micro-courses to Master certification. 120+ countries. Trust score boosts on completion.',
+  title: 'Pilot Car & Escort Operator Training — Get Certified | Haul Command',
+  description:
+    'Pilot car and escort operator certification for heavy haul, wind, oilfield, port, superload, and AV corridors. State-aware and global-ready training pathways for operators, brokers, and fleets. 120 countries.',
+  keywords: [
+    'pilot car certification', 'escort operator training', 'PEVO course',
+    'pilot car training online', 'escort vehicle operator certification',
+    'heavy haul training', 'oversize load escort training', 'AV escort certification',
+    'pilot car training state requirements', 'HC certified training',
+  ],
   alternates: { canonical: 'https://www.haulcommand.com/training' },
+  openGraph: {
+    title: 'Pilot Car & Escort Operator Training | Haul Command',
+    description: 'State-aware, globally-ready pilot car and escort operator certification. From free fundamentals to Elite. 120 countries.',
+    url: 'https://www.haulcommand.com/training',
+    siteName: 'Haul Command',
+    type: 'website',
+  },
 }
 
-const TIERS = [
-  { key:'free',         label:'Free',           color:'#566880',  bg:'#0f1a24', price:'$0',    boost:0,   desc:'7-minute intros. No login required. Start here.',        icon:'▶' },
-  { key:'tier1',        label:'Foundation',     color:'#3b82f6',  bg:'#0a1929', price:'$49',  boost:10,  desc:'4-hour global fundamentals. Accepted in all 120 countries.', icon:'◆' },
-  { key:'tier2_us',     label:'US State Cert',  color:'#8b5cf6',  bg:'#13102a', price:'$149–$299', boost:25, desc:'Official PEVO certifications by state. Reciprocity included.', icon:'★' },
-  { key:'tier2_intl',   label:'Intl Cert',      color:'#d4950e',  bg:'#1a1200', price:'$195+', boost:50, desc:'First-mover national certifications. AU, CA, UK, DE, AE, BR, ZA, NZ.', icon:'🌐' },
-  { key:'tier3_specialist', label:'Specialist', color:'#22c55e',  bg:'#0a1f10', price:'$295–$495', boost:75, desc:'High pole, steerman, route survey, TWIC, military, renewable.', icon:'⬡' },
-  { key:'tier4_master', label:'Master',         color:'#f59e0b',  bg:'#1f1500', price:'$795–$1,495', boost:100, desc:'The highest HC credential. Elite badge, directory boost, priority dispatch.', icon:'👑' },
+// ─── STATIC MODULE DATA (always renders in HTML for Googlebot) ───────────────
+export const MODULES = [
+  {
+    slot: 1,
+    slug: 'pilot-car-fundamentals',
+    title: 'Pilot Car Fundamentals',
+    description:
+      'Safety basics, escort vehicle roles, required equipment, convoy flow, terminology, and the legal framework every escort operator must know before their first move.',
+    audience: 'New operators, career changers, new-to-US international operators',
+    duration: '35 min',
+    outcomes: ['Understand escort roles and responsibilities', 'Know required equipment by jurisdiction', 'Pass state knowledge checks'],
+    tier: 'HC Certified',
+    isFree: true,
+  },
+  {
+    slot: 2,
+    slug: 'route-survey-clearance-intelligence',
+    title: 'Route Survey & Clearance Intelligence',
+    description:
+      'Heights, widths, vertical and horizontal clearance measurement, obstacle documentation, route planning workflows, and how to log and report route hazards.',
+    audience: 'Operators pursuing route survey work, broker-side planners',
+    duration: '40 min',
+    outcomes: ['Conduct a legal route survey', 'Document clearance data accurately', 'Identify and report route hazards'],
+    tier: 'HC Certified',
+    isFree: false,
+  },
+  {
+    slot: 3,
+    slug: 'state-jurisdiction-compliance',
+    title: 'State & Jurisdiction Compliance',
+    description:
+      'Permit touchpoints, signage requirements, lighting rules, escort formation rules by state, common compliance triggers, and how to stay legal across state lines.',
+    audience: 'All operators running permitted loads across state lines',
+    duration: '45 min',
+    outcomes: ['Identify escort requirements in any US state', 'Avoid common compliance failures', 'Navigate multi-state permit chains'],
+    tier: 'HC Certified',
+    isFree: false,
+  },
+  {
+    slot: 4,
+    slug: 'communication-convoy-control',
+    title: 'Communication, Convoy Control & Incident Response',
+    description:
+      'Radio discipline, position call conventions, emergency stop procedures, intersection management, lane coordination, and how to handle stoppages, breakdowns, and incidents.',
+    audience: 'All operators; required for AV-Ready certification',
+    duration: '40 min',
+    outcomes: ['Run professional radio communication', 'Manage convoy incidents safely', 'Coordinate multi-vehicle escorts'],
+    tier: 'AV-Ready',
+    isFree: false,
+  },
+  {
+    slot: 5,
+    slug: 'broker-carrier-load-workflow',
+    title: 'Broker, Carrier & Load Workflow',
+    description:
+      'Dispatch handoff discipline, load documentation, ETA and status reporting expectations, carrier and broker communication norms, and how to handle load changes mid-route.',
+    audience: 'Operators working with brokers and carriers; broker-side planners',
+    duration: '35 min',
+    outcomes: ['Work professionally with brokers and carriers', 'Handle dispatch changes mid-load', 'Document load execution correctly'],
+    tier: 'AV-Ready',
+    isFree: false,
+  },
+  {
+    slot: 6,
+    slug: 'specialized-vertical-operations',
+    title: 'Specialized Vertical Operations',
+    description:
+      'Wind energy escort specifics, superload planning, oilfield escort norms, port and TWIC-adjacent procedures, military and aerospace load handling, and renewable energy project cargo.',
+    audience: 'Operators pursuing specialist and premium corridor work',
+    duration: '50 min',
+    outcomes: ['Qualify for wind, superload, and oilfield work', 'Understand port and TWIC procedures', 'Operate in military and aerospace contexts'],
+    tier: 'Elite',
+    isFree: false,
+  },
+  {
+    slot: 7,
+    slug: 'digital-operations-haul-command',
+    title: 'Digital Operations & Haul Command Advantage',
+    description:
+      'Haul Command profile setup, badge verification, trust signals, marketplace leverage, how brokers search and rank operators, and how to use digital tools to earn more corridor work.',
+    audience: 'All operators; essential for maximizing platform and marketplace earnings',
+    duration: '30 min',
+    outcomes: ['Maximize Haul Command profile rank', 'Earn verified badge and trust signals', 'Attract broker contact and corridor job requests'],
+    tier: 'HC Certified',
+    isFree: true,
+  },
 ]
 
-async function getCourses() {
-  const supabase = createClient()
-  const { data } = await supabase
-    .from('hc_training_courses')
-    .select('id,slug,title,description,tier,price_cents,currency,duration_hours,modules_count,hc_trust_score_boost,certification_level,is_featured,tags,country_codes')
-    .eq('is_active', true)
-    .order('sort_order')
-  return data ?? []
+// ─── STATIC FAQ DATA (answers always in HTML — required for FAQPage schema) ──
+const FAQS = [
+  {
+    q: 'What is pilot car training?',
+    a: 'Pilot car training teaches escort vehicle operators how to safely lead or follow oversize and overweight loads on public roads. It covers equipment requirements, communication protocols, route surveying, state compliance rules, and convoy management. Haul Command Training is built on FMCSA and SC&RA Best Practices Guidelines.',
+  },
+  {
+    q: 'Who is this training for?',
+    a: 'This training is for pilot car operators, escort vehicle operators, heavy haul brokers, fleet managers, dispatchers, and enterprise teams that need certified escort capacity. It is relevant for both US-based and international operations.',
+  },
+  {
+    q: 'Is this training required in every state or country?',
+    a: 'Requirements vary. Twelve US states currently mandate pilot car certification. The HC Certified curriculum meets or exceeds the curriculum requirements for all 12 states. International requirements vary by country — see the country training pages for jurisdiction-specific details.',
+  },
+  {
+    q: 'What does the Haul Command certification badge actually prove?',
+    a: 'The HC badge verifies that you completed the HC training curriculum, which is built on FMCSA, CVSA, and SC&RA Best Practices Guidelines. It does not automatically replace state-issued certifications where those are required, but it signals professional knowledge, equipment familiarity, and platform trust to brokers and carriers.',
+  },
+  {
+    q: 'How long does the training take?',
+    a: 'Module 1 (Pilot Car Fundamentals) takes approximately 35 minutes and is free. HC Certified (modules 1–3) takes approximately 2 hours. AV-Ready (modules 1–5) takes approximately 3.5 hours. Elite (all 7 modules) takes approximately 4.5 hours total. All modules are self-paced.',
+  },
+  {
+    q: 'Is it self-paced?',
+    a: 'Yes. All Haul Command Training modules are fully self-paced. You can start, stop, and resume at any time. Progress is saved to your account.',
+  },
+  {
+    q: 'Does this training help me get more jobs?',
+    a: 'Yes. Certified operators receive a verified badge on their Haul Command profile, which is visible to brokers and carriers during search. Certified operators consistently receive more broker contact requests and qualify for higher-value loads including wind, superload, oilfield, and AV corridor work.',
+  },
+  {
+    q: 'Can brokers verify my certification status?',
+    a: 'Yes. Every HC badge includes an instant verification link. Brokers and carriers can verify your certification status without contacting you, which reduces friction and increases close rate on booking requests.',
+  },
+  {
+    q: 'Is there training for fleets or corporate teams?',
+    a: 'Yes. Haul Command offers corporate and fleet enrollment with volume pricing, team progress tracking, and compliance reporting. See the Corporate Training page for details.',
+  },
+  {
+    q: 'Does this training cover AV corridor escort work?',
+    a: 'Yes. The AV-Ready certification tier (modules 1–5) includes training on how to work alongside autonomous freight systems including Aurora, Kodiak, and Waabi platforms. It covers communication protocols, sensor field awareness, and country-specific AV regulations.',
+  },
+  {
+    q: 'Can I take this training outside the United States?',
+    a: 'Yes. Haul Command Training is designed for global operations and is available in 120 countries. Country-specific training pages are available for the US, Canada, Australia, UK, UAE, and other markets, with localized requirements and terminology.',
+  },
+  {
+    q: 'How often do I need to renew my certification?',
+    a: 'Certification renewal is annual. You receive reminder notifications 30 days and 7 days before expiry. Renewal costs less than initial certification. Your badge shows a renewal prompt to brokers if expired so you never lose work unexpectedly.',
+  },
+  {
+    q: 'What is the difference between HC Certified, AV-Ready, and Elite?',
+    a: 'HC Certified (modules 1–3) covers pilot car fundamentals, route surveying, and jurisdiction compliance — the global baseline. AV-Ready (modules 1–5) adds convoy communication and broker/carrier workflow training, plus AV corridor readiness. Elite (all 7 modules) adds specialized vertical operations including wind, superload, oilfield, port, military, and aerospace, plus full digital operations training.',
+  },
+]
+
+// ─── SCHEMA BLOCKS ─────────────────────────────────────────────────────────
+function buildSchema(courses: any[]) {
+  const courseList = {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    name: 'Pilot Car & Escort Operator Training — Haul Command',
+    description: 'Global pilot car and escort operator certification training. HC Certified, AV-Ready, and Elite pathways. 120 countries.',
+    url: 'https://www.haulcommand.com/training',
+    numberOfItems: MODULES.length,
+    itemListElement: MODULES.map((m, i) => ({
+      '@type': 'ListItem',
+      position: i + 1,
+      item: {
+        '@type': 'Course',
+        name: m.title,
+        description: m.description,
+        provider: { '@type': 'Organization', name: 'Haul Command', url: 'https://www.haulcommand.com' },
+        url: `https://www.haulcommand.com/training/${m.slug}`,
+        timeRequired: `PT${m.duration.replace(' min', 'M')}`,
+        isAccessibleForFree: m.isFree,
+        educationalLevel: m.tier,
+        teaches: m.outcomes,
+      },
+    })),
+  }
+
+  const faqSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: FAQS.map(f => ({
+      '@type': 'Question',
+      name: f.q,
+      acceptedAnswer: { '@type': 'Answer', text: f.a },
+    })),
+  }
+
+  const breadcrumb = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.haulcommand.com' },
+      { '@type': 'ListItem', position: 2, name: 'Training', item: 'https://www.haulcommand.com/training' },
+    ],
+  }
+
+  return [courseList, faqSchema, breadcrumb]
 }
 
-function fmtPrice(cents: number, currency: string) {
-  if (cents === 0) return 'FREE'
-  const sym: Record<string,string> = { USD:'$', AUD:'A$', CAD:'C$', GBP:'£', EUR:'€', AED:'AED ', BRL:'R$', ZAR:'R', NZD:'NZ$' }
-  return `${sym[currency]??''}${(cents/100).toLocaleString()}`
+// ─── TIER COLOR MAP ─────────────────────────────────────────────────────────
+const TIER_COLOR: Record<string, string> = {
+  'HC Certified': '#A8A8A8',
+  'AV-Ready': '#F5A623',
+  'Elite': '#E5E4E2',
 }
 
-const schemaOrg = {
-  '@context':'https://schema.org','@type':'ItemList',
-  name:'HC Training Academy — Heavy Haul Certifications',
-  description:'Global pilot car and heavy haul training platform. Free to Master tier. 120 countries.',
-  url:'https://www.haulcommand.com/training',
+const gold = '#D4A844'
+const s = {
+  page: { minHeight: '100vh', background: '#07090d', color: '#e8e8e8' } as const,
+  container: { maxWidth: 1100, margin: '0 auto', padding: '0 20px' } as const,
 }
 
+// ─── PAGE ───────────────────────────────────────────────────────────────────
 export default async function TrainingPage() {
-  const courses = await getCourses()
-  const byCourses = (tier: string) => courses.filter(c=>c.tier===tier)
+  // Pull live course data to overlay on static modules (optional enrichment)
+  let liveCourses: any[] = []
+  try {
+    const supabase = createClient()
+    const { data } = await (supabase as any)
+      .from('hc_training_courses')
+      .select('slug,price_cents,currency,is_active')
+      .eq('is_active', true)
+    liveCourses = data ?? []
+  } catch { /* graceful — static data always renders */ }
+
+  const liveBySlug = Object.fromEntries(liveCourses.map(c => [c.slug, c]))
+  const schemas = buildSchema(liveCourses)
 
   return (
     <>
-      <JsonLd data={schemaOrg}/>
-      <div className="min-h-screen bg-[#07090d] text-[#f0f2f5]">
+      {schemas.map((s, i) => <JsonLd key={i} data={s} />)}
 
-        {/* HERO */}
-        <div className="relative overflow-hidden border-b border-[#131c28]">
-          <div className="absolute inset-0 bg-gradient-to-br from-[#0a1929] via-[#07090d] to-[#07090d]" />
-          <div className="relative px-4 lg:px-10 py-16 max-w-5xl mx-auto">
-            <p className="text-[11px] tracking-[0.2em] text-[#d4950e] font-semibold mb-4">HC TRAINING ACADEMY · 120 COUNTRIES</p>
-            <h1 className="text-3xl lg:text-5xl font-extrabold tracking-tight text-[#f0f2f5] mb-5 max-w-3xl leading-tight">
-              The Only Global<br/>Heavy Haul Certification Platform
+      <div style={s.page}>
+
+        {/* ── BREADCRUMB ─────────────────────────────────────────────── */}
+        <nav aria-label="Breadcrumb" style={{ borderBottom: '1px solid rgba(255,255,255,0.05)', padding: '12px 0' }}>
+          <div style={{ ...s.container, display: 'flex', gap: 6, fontSize: 11, color: '#6b7280', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.08em' }}>
+            <Link href="/" style={{ color: '#6b7280', textDecoration: 'none' }}>Home</Link>
+            <span>›</span>
+            <span style={{ color: gold }}>Training</span>
+          </div>
+        </nav>
+
+        {/* ── JUMP NAV ───────────────────────────────────────────────── */}
+        <nav aria-label="Page sections" style={{ borderBottom: '1px solid rgba(255,255,255,0.04)', background: 'rgba(255,255,255,0.02)', padding: '10px 0', overflowX: 'auto' }}>
+          <div style={{ ...s.container, display: 'flex', gap: 20, fontSize: 12, fontWeight: 600, whiteSpace: 'nowrap' }}>
+            {[
+              ['#overview', 'Overview'],
+              ['#modules', 'All 7 Modules'],
+              ['#outcomes', 'Outcomes'],
+              ['#pricing', 'Pricing'],
+              ['#countries', 'Countries & States'],
+              ['#faq', 'FAQ'],
+              ['/training/corporate', 'Corporate Training'],
+            ].map(([href, label]) => (
+              <a key={href} href={href} style={{ color: '#9ca3af', textDecoration: 'none' }}>{label}</a>
+            ))}
+          </div>
+        </nav>
+
+        {/* ── HERO ───────────────────────────────────────────────────── */}
+        <section id="overview" style={{ borderBottom: '1px solid rgba(255,255,255,0.06)', padding: 'clamp(2.5rem,6vw,5rem) 20px clamp(2rem,4vw,3.5rem)', position: 'relative', overflow: 'hidden' }}>
+          <div style={{ position: 'absolute', inset: 0, background: 'radial-gradient(ellipse 70% 50% at 50% -10%, rgba(212,168,68,0.1), transparent 65%)', pointerEvents: 'none' }} />
+          <div style={{ ...s.container, position: 'relative' }}>
+
+            {/* Kicker */}
+            <div style={{ display: 'inline-flex', alignItems: 'center', gap: 6, padding: '4px 12px', background: 'rgba(212,168,68,0.1)', border: '1px solid rgba(212,168,68,0.25)', borderRadius: 20, marginBottom: 16 }}>
+              <span style={{ width: 6, height: 6, borderRadius: '50%', background: '#22C55E', boxShadow: '0 0 6px #22C55E' }} />
+              <span style={{ fontSize: 11, fontWeight: 700, color: gold, textTransform: 'uppercase', letterSpacing: '0.1em' }}>HC Training Academy · 120 Countries</span>
+            </div>
+
+            {/* H1 — keyword-first */}
+            <h1 style={{ margin: '0 0 10px', fontSize: 'clamp(2rem,5vw,3.5rem)', fontWeight: 900, lineHeight: 1.05, letterSpacing: '-0.035em', color: '#f9fafb' }}>
+              Pilot Car &amp; Escort<br />
+              <span style={{ color: gold }}>Operator Training</span>
             </h1>
-            <p className="text-sm lg:text-base text-[#8a9ab0] mb-8 max-w-2xl leading-relaxed">
-              From your first free 7-minute explainer to the highest Master credential — every course boosts your HC Trust Score, improves your directory rank, and opens higher-value loads.
+
+            {/* Emotional subhead */}
+            <p style={{ margin: '0 0 12px', fontSize: 'clamp(1rem,2vw,1.25rem)', fontWeight: 700, color: '#d1d5db' }}>
+              Get Certified. Get Chosen First.
             </p>
-            <div className="flex flex-wrap gap-3">
-              <Link href="#free" className="bg-[#d4950e] hover:bg-[#c4850e] text-black font-bold px-5 py-2.5 rounded-xl text-sm transition-colors">Start Free ▶</Link>
-              <Link href="#tier2_us" className="border border-[#8b5cf6] text-[#8b5cf6] hover:bg-[#8b5cf640] font-semibold px-5 py-2.5 rounded-xl text-sm transition-colors">View US Certifications</Link>
-              <Link href="#tier2_intl" className="border border-[#d4950e40] text-[#d4950e] hover:bg-[#d4950e20] font-semibold px-5 py-2.5 rounded-xl text-sm transition-colors">International Certs</Link>
+
+            <p style={{ margin: '0 0 28px', fontSize: 16, color: '#9ca3af', lineHeight: 1.7, maxWidth: 600 }}>
+              The only global training platform built for pilot car and escort operators working in
+              heavy haul, wind energy, oilfield, superload, port, and autonomous vehicle corridors.
+              State-aware. Global-ready. Free to start.
+            </p>
+
+            {/* CTAs */}
+            <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap', marginBottom: 28 }}>
+              <Link href="/training/pilot-car-fundamentals" style={{ display: 'inline-flex', alignItems: 'center', gap: 8, padding: '14px 28px', borderRadius: 12, background: `linear-gradient(135deg, ${gold}, #E4B872)`, color: '#000', fontSize: 14, fontWeight: 900, textDecoration: 'none' }}>
+                🎓 Start Free — Module 1
+              </Link>
+              <a href="#modules" style={{ display: 'inline-flex', alignItems: 'center', gap: 8, padding: '14px 24px', borderRadius: 12, background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.1)', color: '#e5e7eb', fontSize: 14, fontWeight: 700, textDecoration: 'none' }}>
+                See All 7 Modules ↓
+              </a>
+              <Link href="/training/corporate" style={{ display: 'inline-flex', alignItems: 'center', gap: 8, padding: '14px 20px', borderRadius: 12, background: 'rgba(139,92,246,0.08)', border: '1px solid rgba(139,92,246,0.2)', color: '#a78bfa', fontSize: 14, fontWeight: 700, textDecoration: 'none' }}>
+                Fleet / Corporate Training →
+              </Link>
+            </div>
+
+            {/* Proof chips */}
+            <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap', fontSize: 12, color: '#6b7280', fontWeight: 600 }}>
+              {[
+                '✓ Built on FMCSA + SC&RA Standards',
+                '✓ Meets all 12 US state cert requirements',
+                '✓ 120 countries',
+                '✓ Digital badge with instant broker verification',
+                '✓ Free to start — Module 1 no login required',
+              ].map(t => <span key={t}>{t}</span>)}
             </div>
           </div>
-        </div>
+        </section>
 
-        <div className="px-4 lg:px-10 py-10 max-w-5xl mx-auto">
-
-          {/* TRUST SCORE EXPLAINER */}
-          <div className="bg-[#0f1a24] border border-[#1e3048] rounded-2xl p-5 mb-10 flex flex-wrap gap-6 items-center">
-            <div className="flex-1 min-w-[200px]">
-              <p className="text-xs text-[#566880] mb-1">HOW TRAINING AFFECTS YOUR PROFILE</p>
-              <p className="text-sm font-semibold text-[#d0dce8] mb-2">Every course completion boosts your HC Trust Score</p>
-              <p className="text-xs text-[#8a9ab0]">Higher trust scores earn better directory placement, priority in load matching, and verified badges visible to brokers before contact.</p>
-            </div>
-            <div className="flex gap-4 flex-wrap">
-              {[['Foundation','+10'],['US Cert','+25'],['Intl Cert','+50'],['Specialist','+75'],['Master','+100']].map(([label,boost])=>(
-                <div key={label} className="text-center">
-                  <p className="text-xl font-black text-[#22c55e]">{boost}</p>
-                  <p className="text-[10px] text-[#566880]">{label}</p>
+        {/* ── WHY THIS MAKES YOU MORE MONEY ─────────────────────────── */}
+        <section id="outcomes" style={{ padding: 'clamp(2rem,4vw,3rem) 20px', borderBottom: '1px solid rgba(255,255,255,0.05)' }}>
+          <div style={s.container}>
+            <h2 style={{ margin: '0 0 6px', fontSize: 18, fontWeight: 800, color: '#f9fafb' }}>
+              Why This Training Makes You More Money and Easier to Trust
+            </h2>
+            <p style={{ margin: '0 0 20px', fontSize: 13, color: '#6b7280' }}>Certification directly improves your position in the Haul Command marketplace.</p>
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px,1fr))', gap: 10 }}>
+              {[
+                { icon: '📈', title: 'Rank higher in directory search', desc: 'Certified operators appear above uncertified operators in broker searches.' },
+                { icon: '🏅', title: 'Earn a visible verification badge', desc: 'Your badge is visible before brokers contact you — reduces friction, boosts close rate.' },
+                { icon: '🚛', title: 'Qualify for higher-value loads', desc: 'Wind, superload, oilfield, port, AV, and military loads require specialist credentials.' },
+                { icon: '⚡', title: 'Reduce broker hesitation', desc: 'Instant badge verification means brokers can trust you without a phone call first.' },
+                { icon: '🌍', title: 'Work across more states and countries', desc: 'HC Certified meets requirements across all 12 US mandatory states and 120 countries.' },
+                { icon: '🤖', title: 'Unlock AV corridor eligibility', desc: 'AV-Ready certification opens escort work alongside autonomous freight fleets.' },
+              ].map(item => (
+                <div key={item.title} style={{ padding: '16px', borderRadius: 12, background: 'rgba(255,255,255,0.025)', border: '1px solid rgba(255,255,255,0.06)' }}>
+                  <div style={{ fontSize: 22, marginBottom: 8 }}>{item.icon}</div>
+                  <div style={{ fontSize: 13, fontWeight: 700, color: '#e5e7eb', marginBottom: 4 }}>{item.title}</div>
+                  <div style={{ fontSize: 12, color: '#6b7280', lineHeight: 1.5 }}>{item.desc}</div>
                 </div>
               ))}
             </div>
           </div>
+        </section>
 
-          <AdGridSlot zone="training_page_top" />
+        {/* ── ROLE PATHS ─────────────────────────────────────────────── */}
+        <section style={{ padding: 'clamp(1.5rem,3vw,2.5rem) 20px', borderBottom: '1px solid rgba(255,255,255,0.05)' }}>
+          <div style={s.container}>
+            <p style={{ fontSize: 12, fontWeight: 700, color: 'rgba(255,255,255,0.35)', textTransform: 'uppercase', letterSpacing: '0.1em', margin: '0 0 12px', textAlign: 'center' }}>Who is this for?</p>
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(200px,1fr))', gap: 10 }}>
+              {[
+                { icon: '🚗', role: "I'm a Pilot Car Operator", desc: 'Get certified, rank higher, unlock better loads', href: '/training/pilot-car-fundamentals', color: gold },
+                { icon: '📋', role: "I'm a Broker or Dispatcher", desc: 'Verify operator certifications, reduce risk', href: '/training/verify', color: '#3B82F6' },
+                { icon: '🚛', role: "I Run a Fleet or Carrier", desc: 'Certify your escort team at volume', href: '/training/corporate', color: '#8B5CF6' },
+                { icon: '🤖', role: 'AV / Enterprise Partner', desc: 'AV-Ready certified escort capacity', href: '/training/av-certification', color: '#22C55E' },
+              ].map(r => (
+                <Link key={r.role} href={r.href} style={{ display: 'flex', flexDirection: 'column', gap: 6, padding: '16px', borderRadius: 12, textDecoration: 'none', background: `${r.color}0a`, border: `1px solid ${r.color}25` }}>
+                  <span style={{ fontSize: 22 }}>{r.icon}</span>
+                  <span style={{ fontSize: 13, fontWeight: 800, color: r.color, lineHeight: 1.2 }}>{r.role}</span>
+                  <span style={{ fontSize: 11, color: 'rgba(255,255,255,0.45)', lineHeight: 1.4 }}>{r.desc}</span>
+                  <span style={{ fontSize: 12, fontWeight: 700, color: r.color, marginTop: 4 }}>Get started →</span>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </section>
 
-          {/* TIER SECTIONS */}
-          {TIERS.map(tier => {
-            const tierCourses = byCourses(tier.key)
-            return (
-              <section key={tier.key} id={tier.key} className="mb-14 scroll-mt-16">
-                {/* TIER HEADER */}
-                <div className="flex items-center gap-4 mb-5">
-                  <div className="w-10 h-10 rounded-xl flex items-center justify-center text-xl" style={{background:tier.bg, border:`1px solid ${tier.color}30`}}>{tier.icon}</div>
-                  <div className="flex-1">
-                    <div className="flex items-center gap-2 flex-wrap">
-                      <span className="text-xs font-bold tracking-widest px-2 py-0.5 rounded" style={{color:tier.color,background:`${tier.color}15`}}>{tier.label.toUpperCase()}</span>
-                      <span className="text-xs text-[#566880]">{tier.price}</span>
-                      {tier.boost>0&&<span className="text-xs text-[#22c55e] bg-[#0d2000] px-2 py-0.5 rounded">Trust +{tier.boost}</span>}
-                    </div>
-                    <p className="text-xs text-[#8a9ab0] mt-0.5">{tier.desc}</p>
-                  </div>
-                </div>
+        {/* ── 7 MODULES IN CRAWLABLE HTML ────────────────────────────── */}
+        <section id="modules" style={{ padding: 'clamp(2rem,4vw,3.5rem) 20px', borderBottom: '1px solid rgba(255,255,255,0.05)' }}>
+          <div style={s.container}>
+            <h2 style={{ margin: '0 0 6px', fontSize: 22, fontWeight: 800, color: '#f9fafb' }}>All 7 Training Modules</h2>
+            <p style={{ margin: '0 0 24px', fontSize: 13, color: '#6b7280', lineHeight: 1.6 }}>
+              Each module is a standalone credential. Work through them in sequence or jump to what you need most.
+              Modules 1 and 7 are free — no account required to start.
+            </p>
 
-                {/* COURSE CARDS */}
-                {tierCourses.length > 0 ? (
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-                    {tierCourses.map(course=>(
-                      <Link key={course.id} href={`/training/${course.slug}`}
-                        className="bg-[#0f1a24] border border-[#1e3048] rounded-xl p-4 flex flex-col gap-3 hover:border-[#d4950e] transition-colors group">
-                        <div className="flex items-start justify-between gap-3">
-                          <div className="flex-1 min-w-0">
-                            <p className="text-sm font-semibold text-[#d0dce8] group-hover:text-[#f0f2f5] leading-snug mb-1">{course.title}</p>
-                            {course.description&&<p className="text-xs text-[#566880] leading-relaxed line-clamp-2">{course.description}</p>}
-                          </div>
-                          {course.is_featured&&<span className="text-[9px] font-bold text-[#d4950e] bg-[#2a1f08] px-1.5 py-0.5 rounded shrink-0 mt-0.5">FEATURED</span>}
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+              {MODULES.map(m => {
+                const live = liveBySlug[m.slug]
+                const tierColor = TIER_COLOR[m.tier] ?? gold
+                return (
+                  <Link key={m.slug} href={`/training/${m.slug}`} style={{ textDecoration: 'none', display: 'block' }}>
+                    <article style={{ background: 'rgba(255,255,255,0.025)', border: '1px solid rgba(255,255,255,0.07)', borderRadius: 14, padding: '20px 22px', display: 'flex', gap: 18, alignItems: 'flex-start' }}>
+                      {/* Slot number */}
+                      <div style={{ width: 44, height: 44, borderRadius: '50%', background: `${tierColor}18`, border: `1px solid ${tierColor}40`, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 16, fontWeight: 800, color: tierColor, flexShrink: 0 }}>
+                        {m.slot}
+                      </div>
+
+                      <div style={{ flex: 1, minWidth: 0 }}>
+                        {/* Title row */}
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', marginBottom: 6 }}>
+                          <h3 style={{ margin: 0, fontSize: 15, fontWeight: 700, color: '#f0f2f5' }}>{m.title}</h3>
+                          {m.isFree && <span style={{ fontSize: 10, fontWeight: 700, background: 'rgba(34,197,94,0.12)', color: '#22C55E', padding: '2px 8px', borderRadius: 20 }}>FREE</span>}
+                          <span style={{ fontSize: 10, fontWeight: 700, background: `${tierColor}18`, color: tierColor, padding: '2px 8px', borderRadius: 20 }}>{m.tier.toUpperCase()}</span>
                         </div>
-                        <div className="flex items-center gap-2 flex-wrap">
-                          <span className="text-[10px] text-[#8ab0d0] bg-[#141e28] px-2 py-0.5 rounded">
-                            {fmtPrice(course.price_cents, course.currency)}
-                          </span>
-                          {course.duration_hours&&<span className="text-[10px] text-[#566880]">{course.duration_hours < 1 ? `${Math.round(course.duration_hours*60)} min` : `${course.duration_hours}hr`}</span>}
-                          {course.modules_count>0&&<span className="text-[10px] text-[#566880]">{course.modules_count} modules</span>}
-                          {course.hc_trust_score_boost>0&&<span className="text-[10px] text-[#22c55e] bg-[#0d2000] px-1.5 py-0.5 rounded">+{course.hc_trust_score_boost} Trust</span>}
-                          {course.certification_level&&<span className="text-[10px] text-[#d4950e] bg-[#2a1f08] px-1.5 py-0.5 rounded">{course.certification_level}</span>}
+
+                        {/* Description — always in HTML */}
+                        <p style={{ margin: '0 0 10px', fontSize: 13, color: '#9ca3af', lineHeight: 1.6 }}>{m.description}</p>
+
+                        {/* Outcomes — always in HTML */}
+                        <ul style={{ margin: 0, padding: 0, listStyle: 'none', display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+                          {m.outcomes.map(o => (
+                            <li key={o} style={{ fontSize: 11, color: '#6b7280', background: 'rgba(255,255,255,0.04)', padding: '3px 10px', borderRadius: 20, border: '1px solid rgba(255,255,255,0.06)' }}>
+                              ✓ {o}
+                            </li>
+                          ))}
+                        </ul>
+
+                        {/* Meta row */}
+                        <div style={{ display: 'flex', gap: 12, marginTop: 10, fontSize: 11, color: '#6b7280', flexWrap: 'wrap' }}>
+                          <span>⏱ {m.duration}</span>
+                          <span>👤 {m.audience}</span>
                         </div>
-                      </Link>
+                      </div>
+
+                      <span style={{ color: tierColor, fontSize: 20, flexShrink: 0 }}>→</span>
+                    </article>
+                  </Link>
+                )
+              })}
+            </div>
+
+            <p style={{ marginTop: 16, fontSize: 12, color: 'rgba(255,255,255,0.25)' }}>
+              Advanced modules also available:{' '}
+              <Link href="/training/av-certification" style={{ color: gold }}>AV Corridor Readiness</Link>,{' '}
+              <Link href="/training/corporate" style={{ color: gold }}>Port &amp; International Ops</Link>,{' '}
+              and more launching Q3 2026.
+            </p>
+          </div>
+        </section>
+
+        {/* ── PRICING TIERS ──────────────────────────────────────────── */}
+        <section id="pricing" style={{ padding: 'clamp(2rem,4vw,3.5rem) 20px', borderBottom: '1px solid rgba(255,255,255,0.05)', background: 'rgba(255,255,255,0.01)' }}>
+          <div style={s.container}>
+            <h2 style={{ margin: '0 0 6px', fontSize: 22, fontWeight: 800, color: '#f9fafb' }}>Choose Your Certification Level</h2>
+            <p style={{ margin: '0 0 24px', fontSize: 13, color: '#6b7280' }}>Start free with HC Certified. Upgrade to AV-Ready or Elite when you're ready to open more doors.</p>
+
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(260px,1fr))', gap: 16 }}>
+              {[
+                {
+                  name: 'HC Certified', color: '#A8A8A8', price: 'Free with Pro / $49 standalone',
+                  modules: 'Modules 1–3', duration: '~2 hours', highlight: false,
+                  benefits: ['HC Certified badge on your profile', 'Recognized across all 120 countries', 'Meets all 12 US mandatory state requirements', 'Digital credential with instant verification link'],
+                  href: '/training/pilot-car-fundamentals', cta: 'Start Free',
+                },
+                {
+                  name: 'AV-Ready', color: '#F5A623', price: '$149/year',
+                  modules: 'Modules 1–5', duration: '~3.5 hours', highlight: true,
+                  benefits: ['Everything in HC Certified', 'AV-Ready gold badge on profile', 'Priority placement in AV corridor searches', 'Aurora + Kodiak protocol training', 'Oilfield Specialist module included'],
+                  href: '/training?enroll=av_ready', cta: 'Get AV-Ready',
+                },
+                {
+                  name: 'Elite', color: '#E5E4E2', price: '$299/year',
+                  modules: 'All 7 Modules', duration: '~4.5 hours', highlight: false,
+                  benefits: ['Everything in AV-Ready', 'Elite platinum badge — top of all results', 'Superload, military &amp; aerospace module', 'International operations module', 'Dedicated account support'],
+                  href: '/training?enroll=elite', cta: 'Become Elite',
+                },
+              ].map(tier => (
+                <div key={tier.name} style={{ background: tier.highlight ? 'linear-gradient(160deg,#141420,#1a1a0a)' : 'rgba(255,255,255,0.025)', border: `1px solid ${tier.highlight ? 'rgba(245,166,35,0.35)' : 'rgba(255,255,255,0.07)'}`, borderRadius: 16, padding: 24, display: 'flex', flexDirection: 'column', position: 'relative' }}>
+                  {tier.highlight && <div style={{ position: 'absolute', top: -12, left: '50%', transform: 'translateX(-50%)', background: 'linear-gradient(90deg,#F5A623,#e08820)', color: '#000', fontSize: 10, fontWeight: 800, padding: '3px 12px', borderRadius: 20, whiteSpace: 'nowrap' }}>⭐ MOST POPULAR</div>}
+                  <div style={{ fontSize: 18, fontWeight: 800, color: tier.color, marginBottom: 6 }}>{tier.name}</div>
+                  <div style={{ fontSize: 22, fontWeight: 900, color: '#fff', marginBottom: 4 }}>{tier.price}</div>
+                  <div style={{ fontSize: 12, color: '#6b7280', marginBottom: 16 }}>{tier.modules} · {tier.duration}</div>
+                  <ul style={{ flex: 1, margin: '0 0 20px', padding: 0, listStyle: 'none', display: 'flex', flexDirection: 'column', gap: 8 }}>
+                    {tier.benefits.map(b => (
+                      <li key={b} style={{ fontSize: 13, color: '#b0b0c0', display: 'flex', gap: 8 }}>
+                        <span style={{ color: tier.color, flexShrink: 0 }}>✓</span>
+                        <span dangerouslySetInnerHTML={{ __html: b }} />
+                      </li>
                     ))}
-                  </div>
-                ) : (
-                  <div className="bg-[#0f1a24] border border-dashed border-[#1e3048] rounded-xl p-6 text-center">
-                    <p className="text-sm text-[#566880] mb-3">Courses launching Q2 2026 — join the waitlist.</p>
-                    <Link href="/waitlist" className="text-xs text-[#d4950e] border border-[#d4950e40] px-4 py-2 rounded-lg hover:bg-[#2a1f08]">Join Waitlist →</Link>
-                  </div>
-                )}
-              </section>
-            )
-          })}
-
-          <AdGridSlot zone="training_page_bottom" />
-
-          {/* BOTTOM CTA */}
-          <div className="bg-gradient-to-r from-[#0f1a24] to-[#0a1929] border border-[#1e3048] rounded-2xl p-8 text-center mt-6">
-            <p className="text-[11px] tracking-[0.15em] text-[#d4950e] font-semibold mb-3">NOT SURE WHERE TO START?</p>
-            <h2 className="text-xl font-bold text-[#f0f2f5] mb-3">Try a free 7-minute course first</h2>
-            <p className="text-sm text-[#8a9ab0] mb-6 max-w-md mx-auto">No account required. See what Haul Command Training is about before committing to a certification.</p>
-            <Link href="#free" className="bg-[#d4950e] hover:bg-[#c4850e] text-black font-bold px-6 py-3 rounded-xl text-sm transition-colors">Start Free Now ▶</Link>
-          </div>
-
-          {/* COUNTRY COVERAGE */}
-          <div className="mt-10 border-t border-[#131c28] pt-8">
-            <p className="text-[10px] tracking-[0.15em] text-[#566880] mb-4">AVAILABLE IN 120 COUNTRIES</p>
-            <div className="flex flex-wrap gap-2">
-              {['US','CA','AU','GB','NZ','ZA','DE','NL','AE','BR','IE','SE','NO','DK','FI','BE','AT','CH','ES','FR','IT','PT','SA','QA','MX','IN','ID','TH'].map(cc=>(
-                <span key={cc} className="text-[10px] bg-[#0f1a24] border border-[#1e3048] text-[#566880] px-2 py-0.5 rounded">{cc}</span>
+                  </ul>
+                  <Link href={tier.href} style={{ display: 'block', textAlign: 'center', padding: '12px 20px', borderRadius: 10, background: tier.highlight ? 'linear-gradient(135deg,#F5A623,#e08820)' : `${tier.color}18`, color: tier.highlight ? '#000' : tier.color, border: `1px solid ${tier.color}40`, fontSize: 14, fontWeight: 800, textDecoration: 'none' }}>
+                    {tier.cta}
+                  </Link>
+                </div>
               ))}
-              <span className="text-[10px] text-[#566880] px-2 py-0.5">+ 92 more</span>
             </div>
           </div>
-        </div>
+        </section>
+
+        {/* ── COUNTRY & STATE COVERAGE ───────────────────────────────── */}
+        <section id="countries" style={{ padding: 'clamp(2rem,4vw,3.5rem) 20px', borderBottom: '1px solid rgba(255,255,255,0.05)' }}>
+          <div style={s.container}>
+            <h2 style={{ margin: '0 0 6px', fontSize: 22, fontWeight: 800, color: '#f9fafb' }}>Training by Country &amp; State</h2>
+            <p style={{ margin: '0 0 20px', fontSize: 13, color: '#6b7280', lineHeight: 1.6 }}>
+              Haul Command Training is built for global operations. Each country and state page includes
+              localized requirements, terminology, and compliance notes.
+            </p>
+
+            {/* Top countries */}
+            <h3 style={{ margin: '0 0 10px', fontSize: 14, fontWeight: 700, color: '#d1d5db' }}>Priority Markets</h3>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 24 }}>
+              {[
+                ['United States', '/training/united-states'],
+                ['Canada', '/training/canada'],
+                ['Australia', '/training/australia'],
+                ['United Kingdom', '/training/united-kingdom'],
+                ['UAE', '/training/uae'],
+                ['New Zealand', '/training/new-zealand'],
+                ['South Africa', '/training/south-africa'],
+                ['Germany', '/training/germany'],
+                ['Netherlands', '/training/netherlands'],
+                ['Brazil', '/training/brazil'],
+              ].map(([label, href]) => (
+                <Link key={href} href={href} style={{ padding: '7px 14px', borderRadius: 999, fontSize: 13, fontWeight: 600, background: 'rgba(212,168,68,0.07)', border: '1px solid rgba(212,168,68,0.2)', color: gold, textDecoration: 'none' }}>
+                  {label}
+                </Link>
+              ))}
+              <Link href="/training/countries" style={{ padding: '7px 14px', borderRadius: 999, fontSize: 13, fontWeight: 600, background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.08)', color: '#9ca3af', textDecoration: 'none' }}>
+                All 120 Countries →
+              </Link>
+            </div>
+
+            {/* US States */}
+            <h3 style={{ margin: '0 0 10px', fontSize: 14, fontWeight: 700, color: '#d1d5db' }}>US State Training &amp; Compliance</h3>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+              {[
+                ['Texas', 'texas'], ['California', 'california'], ['Florida', 'florida'],
+                ['Washington', 'washington'], ['Arizona', 'arizona'], ['Colorado', 'colorado'],
+                ['Georgia', 'georgia'], ['Ohio', 'ohio'], ['Louisiana', 'louisiana'],
+                ['Pennsylvania', 'pennsylvania'], ['Oregon', 'oregon'], ['North Carolina', 'north-carolina'],
+              ].map(([label, slug]) => (
+                <Link key={slug} href={`/training/united-states/${slug}`} style={{ padding: '6px 13px', borderRadius: 999, fontSize: 12, fontWeight: 600, background: 'rgba(255,255,255,0.03)', border: '1px solid rgba(255,255,255,0.07)', color: '#9ca3af', textDecoration: 'none' }}>
+                  {label}
+                </Link>
+              ))}
+              <Link href="/escort-requirements" style={{ padding: '6px 13px', borderRadius: 999, fontSize: 12, fontWeight: 700, background: 'rgba(212,168,68,0.07)', border: '1px solid rgba(212,168,68,0.18)', color: gold, textDecoration: 'none' }}>
+                All State Requirements →
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        {/* ── FAQ — ANSWERS ALWAYS IN HTML ───────────────────────────── */}
+        <section id="faq" style={{ padding: 'clamp(2rem,4vw,3.5rem) 20px', borderBottom: '1px solid rgba(255,255,255,0.05)' }}>
+          <div style={{ ...s.container, maxWidth: 820 }}>
+            <h2 style={{ margin: '0 0 6px', fontSize: 22, fontWeight: 800, color: '#f9fafb' }}>Frequently Asked Questions</h2>
+            <p style={{ margin: '0 0 24px', fontSize: 13, color: '#6b7280' }}>Everything you need to know before you start.</p>
+
+            {/* Native <details> — crawlable, no JS required */}
+            {FAQS.map((faq, i) => (
+              <details key={i} style={{ marginBottom: 10, borderRadius: 12, background: 'rgba(255,255,255,0.025)', border: '1px solid rgba(255,255,255,0.06)', overflow: 'hidden' }}>
+                <summary style={{ padding: '16px 18px', cursor: 'pointer', fontWeight: 700, fontSize: 14, listStyle: 'none', display: 'flex', alignItems: 'center', gap: 10, color: '#e5e7eb' }}>
+                  <span style={{ color: gold, flexShrink: 0 }}>+</span>
+                  {faq.q}
+                </summary>
+                {/* Answer always present in DOM — visible to Googlebot */}
+                <p style={{ padding: '0 18px 16px', margin: 0, fontSize: 13, color: 'rgba(255,255,255,0.6)', lineHeight: 1.7, borderTop: '1px solid rgba(255,255,255,0.05)' }}>
+                  {faq.a}
+                </p>
+              </details>
+            ))}
+          </div>
+        </section>
+
+        {/* ── RELATED LINKS (no dead end) ────────────────────────────── */}
+        <section style={{ padding: 'clamp(1.5rem,3vw,2.5rem) 20px', borderBottom: '1px solid rgba(255,255,255,0.05)', background: 'rgba(255,255,255,0.01)' }}>
+          <div style={s.container}>
+            <p style={{ margin: '0 0 14px', fontSize: 12, fontWeight: 700, color: 'rgba(255,255,255,0.3)', textTransform: 'uppercase', letterSpacing: '0.1em' }}>Related Resources</p>
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(180px,1fr))', gap: 8 }}>
+              {[
+                { href: '/escort-requirements', label: '📋 Escort Requirements by State', desc: 'What each state mandates' },
+                { href: '/glossary', label: '📚 Heavy Haul Glossary', desc: 'Terms every operator must know' },
+                { href: '/directory', label: '🔍 Find Pilot Car Operators', desc: 'Search the directory' },
+                { href: '/tools/escort-calculator', label: '🧮 Escort Vehicle Calculator', desc: 'How many escorts required' },
+                { href: '/rates', label: '💵 Pilot Car Rate Index', desc: 'Current mileage rates by state' },
+                { href: '/training/verify', label: '✓ Verify a Certification', desc: 'Check badge status instantly' },
+                { href: '/training/corporate', label: '🏢 Corporate Training', desc: 'Certify your fleet' },
+                { href: '/claim', label: '📌 Claim Your Listing', desc: 'Get found by brokers' },
+                { href: '/loads', label: '📦 Browse Escort Jobs', label2: 'Active loads needing escorts', desc: 'Active loads needing escorts' },
+                { href: '/corridors', label: '🛣 Corridor Intelligence', desc: 'Top-ranked routes' },
+                { href: '/leaderboards', label: '🏆 Operator Leaderboard', desc: 'Top operators by corridor' },
+                { href: '/pricing', label: '💎 Pro Membership', desc: 'Priority directory placement' },
+              ].map(link => (
+                <Link key={link.href} href={link.href} style={{ display: 'flex', flexDirection: 'column', gap: 2, padding: '12px 14px', borderRadius: 10, background: 'rgba(255,255,255,0.025)', border: '1px solid rgba(255,255,255,0.06)', textDecoration: 'none' }}>
+                  <span style={{ fontSize: 13, fontWeight: 600, color: '#d1d5db' }}>{link.label}</span>
+                  <span style={{ fontSize: 11, color: '#6b7280' }}>{link.desc}</span>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* ── BOTTOM CTA ─────────────────────────────────────────────── */}
+        <section style={{ padding: 'clamp(2rem,4vw,3.5rem) 20px', textAlign: 'center' }}>
+          <div style={{ ...s.container, maxWidth: 640 }}>
+            <h2 style={{ margin: '0 0 12px', fontSize: 24, fontWeight: 900, color: '#f9fafb' }}>Start Earning Your Badge Today</h2>
+            <p style={{ margin: '0 0 24px', fontSize: 14, color: '#6b7280', lineHeight: 1.7 }}>
+              Module 1 is completely free. No account required. Your verified badge goes live the moment you pass.
+              Brokers and AV companies can verify it instantly.
+            </p>
+            <Link href="/training/pilot-car-fundamentals" style={{ display: 'inline-flex', alignItems: 'center', gap: 10, padding: '16px 36px', borderRadius: 14, background: `linear-gradient(135deg, ${gold}, #E4B872)`, color: '#000', fontSize: 16, fontWeight: 900, textDecoration: 'none', boxShadow: `0 6px 30px rgba(212,168,68,0.4)` }}>
+              🎓 Start Module 1 — Free
+            </Link>
+            <div style={{ marginTop: 16 }}>
+              <Link href="/training/corporate" style={{ fontSize: 13, color: '#6b7280', textDecoration: 'none', borderBottom: '1px solid rgba(255,255,255,0.1)' }}>
+                Certifying a team or fleet? View Corporate Training →
+              </Link>
+            </div>
+          </div>
+        </section>
+
       </div>
     </>
   )


### PR DESCRIPTION
# Training Page SEO Rebuild

## The 5 highest-ROI fixes executed

### 1. 7 modules always in crawlable HTML
`MODULES` is now a static SSR export in `app/training/page.tsx`. Every module title, description, outcomes, audience, and duration renders at request time — no JS required. Googlebot sees all 7 modules on every crawl.

### 2. FAQ answers always in HTML
Replaced the JS `expandedFaq` toggle with native HTML `<details>`/`<summary>` elements. All 13 FAQ answers are in the DOM on first render. FAQPage structured data now aligns with what Googlebot actually sees.

### 3. Keyword-first H1
**Before:** `Get Certified. Get Chosen First.`
**After:** `Pilot Car & Escort Operator Training` (H1) → `Get Certified. Get Chosen First.` (subhead)

### 4. Course + FAQPage + BreadcrumbList schema
All three schema types render as `<script type="application/ld+json">` via SSR. `ItemList` contains all 7 modules as `Course` items. FAQPage has all 13 Q&A pairs with full answer text. BreadcrumbList covers Home › Training.

### 5. 12 related links — no dead ends
New "Related Resources" grid links to: escort requirements, glossary, directory, escort calculator, rate index, verify, corporate training, claim, loads, corridors, leaderboard, pricing.

---

## New routes added

| Route | Purpose |
|-------|---------|
| `app/training/[country]/page.tsx` | Country-specific training page with localized notes, terminology, US state drill-down |
| `app/training/[country]/[state]/page.tsx` | State-level pages with mandatory cert flag, state FAQ, related links |
| `app/training/countries/page.tsx` | Index of all 120 countries by region, crawlable links |
| `app/training/[slug]/page.tsx` | Module pages now have SSR wrapper: Course schema, crawlable H1, outcomes, prev/next nav |

## Also added
- **"Why This Makes You More Money"** section — 6 benefits linking training to earnings
- **Role-path cards** — Operator / Broker / Fleet / AV paths with real `<a href>` links
- **Pricing tiers** in static SSR HTML (no longer DB-only)
- **Country selector** with real crawlable links to priority markets + US states
- **Jump nav** with in-page section anchors
- **Module prev/next navigation** in SSR wrapper

## Acceptance tests
- [ ] `curl https://www.haulcommand.com/training | grep "Pilot Car Fundamentals"` — returns all 7 module titles
- [ ] `curl https://www.haulcommand.com/training | grep "acceptedAnswer"` — FAQ schema present
- [ ] `/training/united-states` renders with Texas, Florida, Washington state links
- [ ] `/training/united-states/washington` shows mandatory certification flag
- [ ] `/training/pilot-car-fundamentals` has Course schema + prev/next links
- [ ] Rich Results Test passes for Course, FAQPage, BreadcrumbList
