### PR TITLE
Wire money loops and LiveKit localization

### DIFF
--- a/app/api/claim/submit/route.ts
+++ b/app/api/claim/submit/route.ts
@@ -2,20 +2,84 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 import { sendPushToUser } from '@/lib/notifications/push-service'
 import { upsertEntity, logActivity } from '@/lib/twenty/client'
+import { COUNTRY_REGISTRY } from '@/lib/config/country-registry'
+
+type MinimalOperator = {
+  id?: string | null
+  is_claimed?: boolean | null
+  country_code?: string | null
+  region_code?: string | null
+  state?: string | null
+  region?: string | null
+  location?: string | null
+}
+
+function normalizeCountryCode(value: unknown): string | null {
+  const code = String(value || '').trim().toUpperCase()
+  return /^[A-Z]{2}$/.test(code) ? code : null
+}
+
+function buildCountryContext(countryCode: string, regionCode?: string | null, roleContext = 'operator_claim') {
+  const country = COUNTRY_REGISTRY.find(c => c.code.toUpperCase() === countryCode.toUpperCase())
+  return {
+    countryCode,
+    regionCode: regionCode || null,
+    roleContext,
+    languageCode: country?.languagePrimary || 'en',
+    secondaryLanguageCode: country?.languageSecondary || null,
+    currencyCode: country?.currency || 'USD',
+    socialPrimary: country?.socialPrimary || 'email',
+    socialSecondary: country?.socialSecondary || 'email',
+    localTone: country?.tone || 'operator_practical',
+    countryName: country?.name || countryCode,
+    tier: country?.tier || 'gold',
+  }
+}
+
+async function findOperatorByHcid(supabase: ReturnType<typeof createClient>, hcid: FormDataEntryValue | null): Promise<MinimalOperator | null> {
+  if (!hcid) return null
+
+  // First try the rich global fields. If this branch is running against an older DB shape,
+  // fall back to the legacy two-column query instead of breaking claim submission.
+  const rich = await supabase
+    .from('operators')
+    .select('id,is_claimed,country_code,region_code,state,region,location')
+    .eq('hc_id', hcid)
+    .single()
+
+  if (!rich.error && rich.data) return rich.data as MinimalOperator
+
+  const legacy = await supabase
+    .from('operators')
+    .select('id,is_claimed')
+    .eq('hc_id', hcid)
+    .single()
+
+  return (legacy.data as MinimalOperator | null) ?? null
+}
+
 export async function POST(req: NextRequest) {
   try {
-    const { hcid, company_name, phone, user_id } = Object.fromEntries(await req.formData())
+    const form = await req.formData()
+    const { hcid, company_name, phone, user_id, country_code, region_code } = Object.fromEntries(form)
     const supabase = createClient()
 
-    // Find operator record
-    let operatorId: string | null = null
-    if (hcid) {
-      const { data: op } = await supabase.from('operators').select('id,is_claimed').eq('hc_id', hcid).single()
-      if (op?.is_claimed) {
-        return NextResponse.redirect(new URL('/claim?error=already_claimed', req.url))
-      }
-      operatorId = op?.id ?? null
+    const op = await findOperatorByHcid(supabase, hcid ?? null)
+    if (op?.is_claimed) {
+      return NextResponse.redirect(new URL('/claim?error=already_claimed', req.url))
     }
+
+    const operatorId = op?.id ?? null
+    const resolvedCountryCode =
+      normalizeCountryCode(country_code) ||
+      normalizeCountryCode(op?.country_code) ||
+      'US'
+
+    const resolvedRegionCode = String(
+      region_code || op?.region_code || op?.state || op?.region || op?.location || ''
+    ).trim() || null
+
+    const countryContext = buildCountryContext(resolvedCountryCode, resolvedRegionCode, 'operator_claim')
 
     // Create trust profile claim record
     const { error } = await supabase.from('hc_trust_profiles').upsert({
@@ -27,6 +91,8 @@ export async function POST(req: NextRequest) {
       claim_company_name: String(company_name),
       claim_phone: String(phone),
       claim_user_id: String(user_id),
+      claim_country_code: resolvedCountryCode,
+      claim_region_code: resolvedRegionCode,
     }, { onConflict: 'entity_id' })
 
     if (error && !error.message.includes('column')) {
@@ -42,9 +108,9 @@ export async function POST(req: NextRequest) {
       deepLink: '/claim/submitted',
       dedupKey: `claim_submitted:${String(hcid ?? user_id)}`,
       dedupWindowHrs: 48,
-    }).catch(()=>{})
+    }).catch(() => {})
 
-    // PHASE 6: TWENTY CRM INTEGRATION - Track Full Lifecycle
+    // TWENTY CRM INTEGRATION - Track full lifecycle
     try {
       const crmEntity = await upsertEntity({
         type: 'claim',
@@ -52,7 +118,13 @@ export async function POST(req: NextRequest) {
         phone: String(phone),
         status: 'pending_verification',
         assignedTo: 'queue_verification',
-        metadata: { hcid: hcid || 'new_operator', user_id }
+        metadata: {
+          hcid: hcid || 'new_operator',
+          user_id,
+          country_code: resolvedCountryCode,
+          region_code: resolvedRegionCode,
+          role_context: 'operator_claim',
+        }
       })
       
       if (crmEntity?.id) {
@@ -68,8 +140,7 @@ export async function POST(req: NextRequest) {
       console.warn('[Twenty] CRM mapping failed, continuing flow:', crmErr)
     }
 
-    // PHASE 5: LIVEKIT INTEGRATION - Trigger AI Verification Call
-    // Fires an asynchronous webhook to the LiveKit outbound route
+    // LIVEKIT INTEGRATION - Trigger AI verification call with 120-country context.
     fetch(new URL('/api/livekit/outbound', req.url).toString(), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -77,10 +148,14 @@ export async function POST(req: NextRequest) {
         targetPhone: String(phone),
         entityId: operatorId ?? user_id,
         programType: 'profile_claim',
-        countryCode: 'US' // Assume US for initial verification
+        countryCode: resolvedCountryCode,
+        regionCode: resolvedRegionCode,
+        languageCode: countryContext.languageCode,
+        currencyCode: countryContext.currencyCode,
+        roleContext: countryContext.roleContext,
+        countryContext,
       })
     }).catch(err => console.warn('[LiveKit] Outbound webhook trigger failed:', err))
-
 
     return NextResponse.redirect(new URL('/claim/submitted', req.url))
   } catch (err: any) {

--- a/app/api/livekit/outbound/route.ts
+++ b/app/api/livekit/outbound/route.ts
@@ -1,20 +1,86 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/utils/supabase/server";
+import { COUNTRY_REGISTRY } from "@/lib/config/country-registry";
+
+type CountryContext = {
+    countryCode: string;
+    regionCode?: string | null;
+    languageCode?: string | null;
+    currencyCode?: string | null;
+    roleContext?: string | null;
+    countryName?: string | null;
+    localTone?: string | null;
+};
+
+function normalizeCountryCode(value: unknown): string {
+    const code = String(value || "US").trim().toUpperCase();
+    return /^[A-Z]{2}$/.test(code) ? code : "US";
+}
+
+function getCountryContext(input: Partial<CountryContext>): Required<CountryContext> {
+    const countryCode = normalizeCountryCode(input.countryCode);
+    const country = COUNTRY_REGISTRY.find(c => c.code.toUpperCase() === countryCode);
+    return {
+        countryCode,
+        regionCode: input.regionCode || null,
+        languageCode: input.languageCode || country?.languagePrimary || "en",
+        currencyCode: input.currencyCode || country?.currency || "USD",
+        roleContext: input.roleContext || "profile_claim",
+        countryName: input.countryName || country?.name || countryCode,
+        localTone: input.localTone || country?.tone || "operator_practical",
+    };
+}
+
+function buildPersonaInstruction(ctx: Required<CountryContext>): string {
+    const country = COUNTRY_REGISTRY.find(c => c.code.toUpperCase() === ctx.countryCode);
+    const language = ctx.languageCode || country?.languagePrimary || "en";
+    const secondary = country?.languageSecondary ? ` If the prospect answers in ${country.languageSecondary}, switch naturally to that language.` : "";
+
+    return [
+        `Adopt the local business communication style for ${ctx.countryName}.`,
+        `Primary language: ${language}. Currency: ${ctx.currencyCode}.`,
+        ctx.regionCode ? `Use local region context: ${ctx.regionCode}.` : "Do not invent a local region if it was not provided.",
+        `Tone target: ${ctx.localTone}.`,
+        `Role context: ${ctx.roleContext}.`,
+        secondary,
+        "Use heavy-haul terminology that fits the market. Do not force U.S.-only terms like PEVO, DOT, FMCSA, state permit, or pilot car unless the country context supports them.",
+        "For compliance claims, be careful: say Haul Command helps verify and organize information, but final legal requirements depend on the local authority and permit office.",
+    ].join(" ");
+}
 
 export async function POST(req: NextRequest) {
     try {
         const body = await req.json();
-        const { targetPhone, entityId, programType = "profile_claim", countryCode } = body;
+        const {
+            targetPhone,
+            entityId,
+            programType = "profile_claim",
+            countryCode,
+            regionCode,
+            languageCode,
+            currencyCode,
+            roleContext,
+            countryContext: suppliedCountryContext,
+        } = body;
 
         if (!targetPhone || !entityId) {
             return NextResponse.json({ error: "targetPhone and entityId are required" }, { status: 400 });
         }
 
+        const ctx = getCountryContext({
+            ...(suppliedCountryContext || {}),
+            countryCode: countryCode || suppliedCountryContext?.countryCode,
+            regionCode: regionCode || suppliedCountryContext?.regionCode,
+            languageCode: languageCode || suppliedCountryContext?.languageCode,
+            currencyCode: currencyCode || suppliedCountryContext?.currencyCode,
+            roleContext: roleContext || suppliedCountryContext?.roleContext || programType,
+        });
+
         const apiKey = process.env.LIVEKIT_API_KEY;
         const apiSecret = process.env.LIVEKIT_API_SECRET;
         
         // HYBRID LCR (LEAST COST ROUTING) DEPLOYMENT
-        // T1 (Telnyx) is 30% cheaper. T2 (Twilio) provides 120-country fallback.
+        // T1 (Telnyx) is cheaper in core markets. T2 (Twilio) provides 120-country fallback.
         const telnyxCoreRegions = ['US', 'CA', 'GB', 'AU', 'DE', 'FR', 'ES', 'IT', 'NL', 'SE'];
         
         // Retrieve explicit hybrid trunk IDs, or fallback to legacy single trunk
@@ -22,7 +88,7 @@ export async function POST(req: NextRequest) {
         const twilioTrunkId = process.env.LIVEKIT_SIP_TRUNK_TWILIO || process.env.LIVEKIT_SIP_TRUNK_ID;
 
         // Dynamic Trunk Selection: Route to T1 if supported, T2 if edge/remote
-        const sipTrunkId = telnyxCoreRegions.includes(countryCode?.toUpperCase() || 'US') 
+        const sipTrunkId = telnyxCoreRegions.includes(ctx.countryCode) 
             ? telnyxTrunkId 
             : twilioTrunkId;
 
@@ -35,39 +101,40 @@ export async function POST(req: NextRequest) {
 
         const roomName = `outbound_${programType}_${entityId}_${Date.now()}`;
 
-        // Prepare SIP Participant Creation request to LiveKit Cloud (Server API)
-        // Note: Actual SDK payload may differ depending on the installed livekit-server-sdk version.
-        // Below is the standard CreateSipParticipant REST format pattern used by LiveKit.
-        // 4. Hyper-Local Persona Injection
-        // Instructs the Voice AI to adopt regional accents, dialects, and formalities to increase conversion
-        const localPersonas: Record<string, string> = {
-            'US': 'Adopt a professional, direct American tone. Use standard logistics terminology.',
-            'CA': 'Adopt a polite, professional Canadian tone. Be helpful and collaborative.',
-            'GB': 'Adopt a professional British accent. Use formal business language.',
-            'AU': 'Adopt a confident, friendly Australian accent. Use straightforward business language.',
-            'MX': 'Adopt a professional Latin American Spanish accent, primarily communicating in Spanish unless spoken to in English. Use standard Mexican logistics terminology.'
-        };
-        const personaInstruction = localPersonas[countryCode?.toUpperCase()] || 'Adopt a neutral, professional business tone.';
+        const personaInstruction = buildPersonaInstruction(ctx);
 
-        // 5. Psychological Behavior Fallbacks (Cole Gordon, Alex Hormozi, Billy Gene models)
-        // Instruct the bot heavily on qualification, value stacking, and anger diffusion.
+        // Psychological behavior fallbacks. Keep this compliant: value-first, consent-aware, DNC-respecting.
         const psychologicalDirectives = `
             STRATEGY:
-            - Speed to logic (Cole Gordon): Qualify them in the first 10 seconds. "Hey, you run heavy haul out of [State], right?"
-            - Disruption (Billy Gene): If they try to hang up quickly, disrupt them. "Wait, before you hang up and leave the directory leads to your competitors..."
-            - Value Stacking (Alex Hormozi): Remove all risk. "It's 100% free to claim, I just need 10 seconds to verify it's you so we can send you loads."
+            - Qualify quickly in the first 10 seconds using the supplied country/region context.
+            - Value-first: explain that claiming is free and helps route relevant broker/operator opportunities.
+            - Do not fabricate leads, revenue, search demand, social proof, authority status, or compliance facts.
+            - Ask permission before continuing if the person sounds busy.
 
             FALLBACK AND ANGER BEHAVIOR:
-            - If they get angry or defensive: Immediately drop the pitch. Diffuse and agree. "I totally understand, you're busy running trucks. I'll take you off the dialer." 
-            - If they explicitly yell or demand to be removed: Say "No problem, taking you off the list now, have a safe drive," and IMMEDIATELY trigger the DNC function.
-            - If they hang up mid-sentence: Do not call back. The system will auto-route them to the SMS/Email fallback sequence.
+            - If they get angry or defensive: drop the pitch, acknowledge, and offer removal from future outreach.
+            - If they explicitly request removal: say "No problem, taking you off the list now, have a safe drive," and trigger the DNC/remove flow.
+            - If they hang up mid-sentence: do not call back automatically. Route them to a compliant SMS/email fallback only if consent and local rules allow it.
         `;
 
-        const systemInstruction = `Outbound sales sequence for ${programType}. ${personaInstruction} The prospect is located in region: ${countryCode}. ${psychologicalDirectives}`;
+        const systemInstruction = `Outbound Haul Command sequence for ${programType}. ${personaInstruction} ${psychologicalDirectives}`;
 
         const livekitUrl = process.env.NEXT_PUBLIC_LIVEKIT_WS_URL 
             ? process.env.NEXT_PUBLIC_LIVEKIT_WS_URL.replace('wss://', 'https://') 
             : 'https://haulcommand.livekit.cloud';
+
+        const livekitMetadata = {
+            programType,
+            targetPhone,
+            entityId,
+            country_code: ctx.countryCode,
+            region_code: ctx.regionCode,
+            language_code: ctx.languageCode,
+            currency_code: ctx.currencyCode,
+            role_context: ctx.roleContext,
+            local_tone: ctx.localTone,
+            system_instruction: systemInstruction,
+        };
 
         const res = await fetch(`${livekitUrl}/twirp/livekit.SIP/CreateSIPParticipant`, {
             method: 'POST',
@@ -80,7 +147,7 @@ export async function POST(req: NextRequest) {
                 sip_call_to: targetPhone,
                 room_name: roomName,
                 participant_identity: `bot_${programType}`,
-                metadata: JSON.stringify({ programType, targetPhone, entityId, system_instruction: systemInstruction }) 
+                metadata: JSON.stringify(livekitMetadata) 
             })
         });
 
@@ -100,10 +167,24 @@ export async function POST(req: NextRequest) {
             participant_identity: `bot_${programType}`,
             call_type: 'outbound_sip',
             status: 'initiated',
-            system_instruction: systemInstruction
+            system_instruction: systemInstruction,
+            country_code: ctx.countryCode,
+            region_code: ctx.regionCode,
+            metadata: livekitMetadata,
+        }).then(({ error }) => {
+            if (error?.message?.includes('column')) {
+                return supabase.from('livekit_call_events').insert({
+                    room_name: roomName,
+                    participant_identity: `bot_${programType}`,
+                    call_type: 'outbound_sip',
+                    status: 'initiated',
+                    system_instruction: systemInstruction,
+                });
+            }
+            return undefined;
         });
 
-        return NextResponse.json({ success: true, roomName }, { status: 200 });
+        return NextResponse.json({ success: true, roomName, country_context: ctx }, { status: 200 });
 
     } catch (e: any) {
         console.error("LiveKit Outbound Error:", e);

--- a/lib/monetization/entitlements.ts
+++ b/lib/monetization/entitlements.ts
@@ -74,14 +74,19 @@ export class EntitlementEngine {
                     const session = event.data.object as Stripe.Checkout.Session;
                     // Legacy type-keyed routes
                     if (session.metadata?.type === 'ad_boost') await this.activateAdGrid(session);
+                    if (session.metadata?.type === 'adgrid_bid') await this.activateAdGridBid(session);
+                    if (session.metadata?.type === 'report_card_unlock') await this.activateReportCardUnlock(session);
+                    if (session.metadata?.type === 'broker_report_subscription') await this.activateBrokerReportSubscription(session);
                     if (session.metadata?.type === 'data_purchase') await this.activateDataProduct(session);
                     if (session.metadata?.type === 'tier2_claim') await this.activateProfileClaim(session);
                     // New creative factory campaigns (/api/ads/campaigns)
                     if (session.metadata?.campaign_id) await this.activateCampaign(session);
                     // New data buy route (/api/data/buy) without legacy type key
                     if (session.metadata?.product_id && !session.metadata?.type) await this.activateDataProduct(session);
-                    // Subscription activation from /api/checkout/session
-                    if (session.metadata?.product_key && session.mode === 'subscription') await this.activateSubscriptionByProductKey(session);
+                    // Subscription activation from /api/checkout/session and /api/subscriptions/checkout
+                    if ((session.metadata?.product_key || session.metadata?.lookup_key) && session.mode === 'subscription') {
+                        await this.activateSubscriptionByProductKey(session);
+                    }
                     break;
                 }
 
@@ -178,6 +183,15 @@ export class EntitlementEngine {
             stripe_session_id: session.id,
         }).eq('id', campaignId);
 
+        await this.recordMoneyEvent({
+            event_type: 'ad_campaign_activated',
+            amount_cents: session.amount_total ?? 0,
+            entity_type: 'ad_campaign',
+            entity_id: campaignId,
+            market: session.metadata?.geo_key || session.metadata?.country_code || 'global',
+            metadata: { stripe_session_id: session.id, campaign_id: campaignId },
+        });
+
         // Swarm attribution
         ;(async () => { try { await this.supabase.from('swarm_activity_log').insert({
             agent_name: 'adgrid_creative_agent',
@@ -189,18 +203,25 @@ export class EntitlementEngine {
         }); } catch {} })();
     }
 
-    // ── 6. Subscription Activation by product_key (from /api/checkout/session) ─
+    // ── 6. Subscription Activation by product_key / lookup_key ────────────────
     private async activateSubscriptionByProductKey(session: Stripe.Checkout.Session) {
         const userId = session.metadata?.user_id;
-        const productKey = session.metadata?.product_key;
+        const productKey = session.metadata?.product_key || session.metadata?.lookup_key;
         if (!userId || !productKey) return;
 
-        // Map product_key → tier name
+        // Map product_key → tier name. Public naming is handled in pricing config / UI;
+        // entitlement values stay stable for code and RLS policies.
         const TIER_MAP: Record<string, string> = {
             'hc_basic_monthly': 'basic',  'hc_basic_annual': 'basic',
             'hc_pro_monthly': 'pro',      'hc_pro_annual': 'pro',
             'hc_elite_monthly': 'elite',  'hc_elite_annual': 'elite',
             'broker_seat_monthly': 'broker', 'broker_seat_annual': 'broker',
+            'directory_pro_monthly': 'pro',
+            'directory_elite_monthly': 'elite',
+            'directory_enterprise_monthly': 'enterprise',
+            'mobile_basic_monthly': 'pro',
+            'mobile_pro_monthly': 'elite',
+            'mobile_elite_monthly': 'enterprise',
         };
         const tier = TIER_MAP[productKey] ?? 'pro';
 
@@ -212,11 +233,21 @@ export class EntitlementEngine {
         await this.supabase.from('user_subscriptions').upsert({
             user_id: userId,
             stripe_session_id: session.id,
+            stripe_subscription_id: typeof session.subscription === 'string' ? session.subscription : undefined,
             plan_id: productKey,
             price_key: productKey,
             status: 'active',
             current_period_start: new Date().toISOString(),
         }, { onConflict: 'user_id' });
+
+        await this.recordMoneyEvent({
+            event_type: 'subscription_activated',
+            amount_cents: session.amount_total ?? 0,
+            entity_type: 'user',
+            entity_id: userId,
+            market: session.metadata?.country_code || 'global',
+            metadata: { stripe_session_id: session.id, product_key: productKey, tier },
+        });
     }
 
     // ── 7. Standard AdGrid Placement ───────────────────────────────────────────
@@ -224,9 +255,133 @@ export class EntitlementEngine {
     private async activateAdGrid(session: Stripe.Checkout.Session) {
         if (!session.metadata?.boost_id) throw new Error('Boost ID missing');
         await this.supabase.from('ad_boosts').update({ status: 'active', starts_at: new Date().toISOString() }).eq('id', session.metadata.boost_id);
+        await this.recordMoneyEvent({
+            event_type: 'adgrid_boost_activated',
+            amount_cents: session.amount_total ?? 0,
+            entity_type: 'ad_boost',
+            entity_id: session.metadata.boost_id,
+            market: session.metadata?.geo_key || session.metadata?.country_code || 'global',
+            metadata: { stripe_session_id: session.id },
+        });
     }
 
-    // ── 6. Escrow Capture on Load Approval ─────────────────────────────────────
+    // ── 8. AdGrid Bid Activation ──────────────────────────────────────────────
+    // Closes the self-serve bid checkout gap from /api/adgrid/bid.
+    private async activateAdGridBid(session: Stripe.Checkout.Session) {
+        const bidId = session.metadata?.bid_id;
+        if (!bidId) throw new Error('AdGrid bid_id missing from checkout session.');
+
+        const subscriptionId = typeof session.subscription === 'string' ? session.subscription : null;
+        const bidAmount = Number(session.metadata?.bid_amount || 0);
+        const geoKey = session.metadata?.geo_key || 'unknown';
+        const slotId = session.metadata?.slot_id || 'unknown';
+        const bidType = session.metadata?.bid_type || 'auction';
+
+        // If this is a guaranteed lock, retire existing active bidders in the same slot.
+        if (bidType === 'guaranteed_lock') {
+            await this.supabase
+                .from('adgrid_bids')
+                .update({ status: 'superseded', superseded_at: new Date().toISOString(), superseded_by_bid_id: bidId })
+                .eq('geo_key', geoKey)
+                .eq('slot_id', slotId)
+                .eq('status', 'active')
+                .neq('id', bidId);
+        }
+
+        const updatePayload: Record<string, any> = {
+            status: 'active',
+            activated_at: new Date().toISOString(),
+            stripe_session_id: session.id,
+            stripe_subscription_id: subscriptionId,
+            amount_paid_cents: session.amount_total ?? Math.round(bidAmount * 100),
+        };
+
+        const { error: richErr } = await this.supabase
+            .from('adgrid_bids')
+            .update(updatePayload)
+            .eq('id', bidId);
+
+        // Older DBs may not have the rich columns yet. Do the minimum activation instead of losing money.
+        if (richErr?.message?.includes('column')) {
+            const { error: fallbackErr } = await this.supabase
+                .from('adgrid_bids')
+                .update({ status: 'active' })
+                .eq('id', bidId);
+            if (fallbackErr) throw fallbackErr;
+        } else if (richErr) {
+            throw richErr;
+        }
+
+        await this.recordMoneyEvent({
+            event_type: 'adgrid_bid_activated',
+            amount_cents: session.amount_total ?? Math.round(bidAmount * 100),
+            entity_type: 'adgrid_bid',
+            entity_id: bidId,
+            market: geoKey,
+            metadata: { stripe_session_id: session.id, slot_id: slotId, bid_type: bidType, subscription_id: subscriptionId },
+        });
+
+        await this.logOsEvent('adgrid.bid_activated', bidId, 'adgrid_bid', {
+            geo_key: geoKey,
+            slot_id: slotId,
+            bid_type: bidType,
+            amount_cents: session.amount_total ?? Math.round(bidAmount * 100),
+        });
+    }
+
+    private async activateReportCardUnlock(session: Stripe.Checkout.Session) {
+        const userId = session.metadata?.user_id;
+        const operatorId = session.metadata?.operator_id;
+        if (!userId || !operatorId) return;
+
+        await this.supabase.from('report_card_unlocks').upsert({
+            user_id: userId,
+            operator_id: operatorId,
+            stripe_session_id: session.id,
+            status: 'active',
+            unlocked_at: new Date().toISOString(),
+            expires_at: new Date(Date.now() + 1000 * 60 * 60 * 24 * 30).toISOString(),
+        }, { onConflict: 'user_id,operator_id' }).then(() => {});
+
+        await this.recordMoneyEvent({
+            event_type: 'report_card_unlock',
+            amount_cents: session.amount_total ?? 0,
+            entity_type: 'operator_report_card',
+            entity_id: operatorId,
+            market: session.metadata?.country_code || 'global',
+            metadata: { user_id: userId, stripe_session_id: session.id },
+        });
+    }
+
+    private async activateBrokerReportSubscription(session: Stripe.Checkout.Session) {
+        const userId = session.metadata?.user_id;
+        if (!userId) return;
+        await this.supabase.from('profiles').update({
+            subscription_tier: 'broker',
+            subscription_status: 'active',
+        }).eq('id', userId);
+
+        await this.supabase.from('user_subscriptions').upsert({
+            user_id: userId,
+            stripe_session_id: session.id,
+            stripe_subscription_id: typeof session.subscription === 'string' ? session.subscription : undefined,
+            plan_id: 'broker_report_subscription',
+            price_key: 'broker_report_subscription',
+            status: 'active',
+            current_period_start: new Date().toISOString(),
+        }, { onConflict: 'user_id' });
+
+        await this.recordMoneyEvent({
+            event_type: 'broker_report_subscription_activated',
+            amount_cents: session.amount_total ?? 0,
+            entity_type: 'user',
+            entity_id: userId,
+            market: session.metadata?.country_code || 'global',
+            metadata: { stripe_session_id: session.id },
+        });
+    }
+
+    // ── 9. Escrow Capture on Load Approval ─────────────────────────────────────
     private async secureLoadEscrowHold(pi: Stripe.PaymentIntent) {
         const loadId = pi.metadata?.job_id || pi.metadata?.load_id;
         if (!loadId) return;
@@ -236,6 +391,14 @@ export class EntitlementEngine {
     private async activateProfileClaim(session: Stripe.Checkout.Session) {
          if (!session.metadata?.profile_id) return;
          await this.supabase.from('profiles').update({ is_claimed: true, claim_status: 'verified' }).eq('id', session.metadata.profile_id);
+         await this.recordMoneyEvent({
+             event_type: 'profile_claim_activated',
+             amount_cents: session.amount_total ?? 0,
+             entity_type: 'profile',
+             entity_id: session.metadata.profile_id,
+             market: session.metadata?.country_code || 'global',
+             metadata: { stripe_session_id: session.id },
+         });
     }
     
     private async handleFailedDunning(invoice: Stripe.Invoice) {
@@ -248,5 +411,33 @@ export class EntitlementEngine {
              await this.supabase.from('user_subscriptions').update({ status: 'past_due' }).eq('user_id', user.user_id);
              await this.supabase.from('profiles').update({ subscription_status: 'past_due' }).eq('id', user.user_id);
          }
+    }
+
+    private async recordMoneyEvent(params: {
+        event_type: string;
+        amount_cents: number;
+        entity_type?: string;
+        entity_id?: string;
+        market?: string;
+        metadata?: Record<string, unknown>;
+    }) {
+        await this.supabase.from('hc_command_money_events').insert({
+            event_type: params.event_type,
+            amount_cents: params.amount_cents,
+            currency: 'USD',
+            entity_type: params.entity_type ?? null,
+            entity_id: params.entity_id ?? null,
+            market: params.market ?? null,
+            metadata: params.metadata ?? {},
+        }).then(() => {});
+    }
+
+    private async logOsEvent(eventType: string, entityId: string, entityType: string, payload: Record<string, unknown>) {
+        await this.supabase.from('os_event_log').insert({
+            event_type: eventType,
+            entity_id: entityId,
+            entity_type: entityType,
+            payload,
+        }).then(() => {});
     }
 }

--- a/lib/subscriptions/pricing-config.ts
+++ b/lib/subscriptions/pricing-config.ts
@@ -3,6 +3,14 @@
 // Haul Command — Global Subscription Pricing Configuration
 // Single source of truth for directory + mobile subscription tiers.
 // PPP-adjusted, cost-floor protected, App Store compliant.
+//
+// Public naming standard:
+// - Road Ready = free/base access
+// - Fast Lane = core paid growth tier
+// - Corridor Elite = premium corridor visibility
+// - Fleet Command = enterprise/fleet/API tier
+//
+// Stripe lookup keys stay stable so existing checkout/webhook/RLS logic does not break.
 
 // ============================================================
 // TYPES
@@ -16,6 +24,7 @@ export interface PricePlan {
     tier: PricingTier;
     platform: Platform;
     name: string;
+    public_name: string;
     tagline: string;
     base_price_usd: number;
     stripe_price_lookup_key: string; // Stripe lookup key for price resolution
@@ -30,6 +39,17 @@ export interface PPPMultiplier {
     multiplier: number;
     countries: string[];
 }
+
+// ============================================================
+// PUBLIC PLAN NAMES
+// ============================================================
+
+export const PUBLIC_PLAN_NAMES: Record<PricingTier, string> = {
+    free: 'Road Ready',
+    pro: 'Fast Lane',
+    elite: 'Corridor Elite',
+    enterprise: 'Fleet Command',
+};
 
 // ============================================================
 // PPP TIERS (Purchasing Power Parity)
@@ -84,7 +104,8 @@ export const DIRECTORY_PLANS: PricePlan[] = [
     {
         tier: 'free',
         platform: 'directory',
-        name: 'Starter Listing',
+        name: 'Road Ready',
+        public_name: 'Road Ready',
         tagline: 'Get discovered by brokers and carriers',
         base_price_usd: 0,
         stripe_price_lookup_key: 'directory_free',
@@ -105,8 +126,9 @@ export const DIRECTORY_PLANS: PricePlan[] = [
     {
         tier: 'pro',
         platform: 'directory',
-        name: 'Verified Pro',
-        tagline: 'Stand out and win more loads',
+        name: 'Fast Lane',
+        public_name: 'Fast Lane',
+        tagline: 'Stand out, respond faster, and win more loads',
         base_price_usd: 29,
         stripe_price_lookup_key: 'directory_pro_monthly',
         features: [
@@ -130,11 +152,12 @@ export const DIRECTORY_PLANS: PricePlan[] = [
         tier: 'elite',
         platform: 'directory',
         name: 'Corridor Elite',
+        public_name: 'Corridor Elite',
         tagline: 'Dominate your corridors',
         base_price_usd: 79,
         stripe_price_lookup_key: 'directory_elite_monthly',
         features: [
-            'Everything in Verified Pro',
+            'Everything in Fast Lane',
             'Top-of-corridor priority placement',
             'Leaderboard visibility boost',
             'Advanced analytics + competitor insights',
@@ -153,7 +176,8 @@ export const DIRECTORY_PLANS: PricePlan[] = [
     {
         tier: 'enterprise',
         platform: 'directory',
-        name: 'Fleet / Enterprise',
+        name: 'Fleet Command',
+        public_name: 'Fleet Command',
         tagline: 'Multi-vehicle operations and API access',
         base_price_usd: 999,
         stripe_price_lookup_key: 'directory_enterprise_monthly',
@@ -184,7 +208,8 @@ export const MOBILE_PLANS: PricePlan[] = [
     {
         tier: 'free',
         platform: 'mobile',
-        name: 'Mobile Free',
+        name: 'Road Ready Mobile',
+        public_name: 'Road Ready',
         tagline: 'Essential tools on the go',
         base_price_usd: 0,
         stripe_price_lookup_key: 'mobile_free',
@@ -204,7 +229,8 @@ export const MOBILE_PLANS: PricePlan[] = [
     {
         tier: 'pro',
         platform: 'mobile',
-        name: 'Mobile Basic',
+        name: 'Fast Lane Mobile',
+        public_name: 'Fast Lane',
         tagline: 'Never miss a load',
         base_price_usd: 4.99,
         stripe_price_lookup_key: 'mobile_basic_monthly',
@@ -225,12 +251,13 @@ export const MOBILE_PLANS: PricePlan[] = [
     {
         tier: 'elite',
         platform: 'mobile',
-        name: 'Mobile Pro',
+        name: 'Corridor Elite Mobile',
+        public_name: 'Corridor Elite',
         tagline: 'Smart matching and route intelligence',
         base_price_usd: 24.99,
         stripe_price_lookup_key: 'mobile_pro_monthly',
         features: [
-            'Everything in Mobile Basic',
+            'Everything in Fast Lane Mobile',
             'Full live job feed',
             'Smart match priority ranking',
             'Route intelligence (basic)',
@@ -249,12 +276,13 @@ export const MOBILE_PLANS: PricePlan[] = [
     {
         tier: 'enterprise',
         platform: 'mobile',
-        name: 'Mobile Elite',
+        name: 'Fleet Command Mobile',
+        public_name: 'Fleet Command',
         tagline: 'Full corridor intelligence and AI dispatch',
         base_price_usd: 59.99,
         stripe_price_lookup_key: 'mobile_elite_monthly',
         features: [
-            'Everything in Mobile Pro',
+            'Everything in Corridor Elite Mobile',
             'Real-time corridor intelligence',
             'Demand heatmaps',
             'Priority dispatch signals',


### PR DESCRIPTION
## Summary
- Closed the AdGrid self-serve bid fulfillment gap by handling `metadata.type === adgrid_bid` in the canonical Stripe entitlement engine.
- Added Command Fabric money-event logging for AdGrid bids, boosts, campaigns, profile claims, subscriptions, broker/report-card subscriptions, and report-card unlocks.
- Removed hardcoded U.S. claim routing by resolving country/region context from claim form/operator data and passing it into LiveKit outbound calls.
- Upgraded LiveKit outbound metadata and persona construction for 120-country-aware country, language, currency, role, and region context.
- Aligned public subscription plan naming with Road Ready, Fast Lane, Corridor Elite, and Fleet Command without changing existing lookup keys.

## Notes
- I kept this as a focused code pass, not a speculative rebuild.
- Some rich DB columns for `adgrid_bids`, `livekit_call_events`, and `hc_trust_profiles` may not exist in older deployments, so the code includes fallback behavior where possible instead of failing the money/claim flow.
- External secrets/config still must exist outside GitHub: LiveKit credentials/SIP trunks, Stripe webhook wiring, and Supabase table migrations if the production DB is missing the rich columns.

## Follow-up for Claude when credits reset
1. Run typecheck/build.
2. Verify the actual Supabase schemas for `adgrid_bids`, `livekit_call_events`, `hc_trust_profiles`, `report_card_unlocks`, `hc_command_money_events`, and `os_event_log`.
3. Add migrations only for missing columns/tables.
4. Verify Stripe webhook path calls `EntitlementEngine.handleStripeWebhook` for checkout events.
5. Test one AdGrid bid checkout end-to-end and one claim submission end-to-end.