### PR TITLE
Add mock-to-live fixtures, position taxonomy, and revenue audit

### DIFF
--- a/docs/audits/mock-to-live-registry.md
+++ b/docs/audits/mock-to-live-registry.md
@@ -1,0 +1,52 @@
+# Haul Command Mock-to-Live Registry
+
+_Last updated: 2026-05-01_
+
+This registry exists to prevent production pages from silently depending on mocks, fake keys, old Pinecone paths, or unverified partner connectors.
+
+## Status labels
+
+- `live`: connected to verified production data/API and safe for public surfaces.
+- `wired_partial`: connected to some real data, but missing critical relationships, coverage, or QA.
+- `fixture_ready`: fixtures exist and can be used for local/dev/seed validation, but production wiring is not complete.
+- `mock_only`: hardcoded arrays, fake returns, fake credentials, or demo-only behavior.
+- `dormant`: connector/module exists but no usable credential/API route/workflow is active.
+- `deprecated`: should be replaced by a newer module.
+- `archived_broken`: preserved for reference only; must not be imported by production code.
+
+## Current high-risk inventory
+
+| Surface / module | Current status | Why it matters | Required next action |
+|---|---|---|---|
+| `app/api/quote/route.ts` | `mock_only` | Hardcoded rate math and mock currency. Does not price steer/tillerman, fifth car, drone survey, police, traffic control, deadhead, layover, corridor demand, or country rules. | Replace with Supabase-backed pricing engine and use `hc_rate_categories` + `hc_hazard_modifiers` fixtures as seed contract. |
+| `lib/ai/vector-layer.ts` | `deprecated` | Still imports Pinecone and returns fake vector results. Haul Command is Supabase-first now. | Replace with Supabase vector/search RPC and remove Pinecone dependency from production paths. |
+| `components/command/GlobalDensityMap.tsx` | `mock_only` | Uses mock Mapbox fallback and only renders passed markers. Does not query live operator/load/gap density. | Wire to Supabase density view: operators, active loads, unclaimed entities, claim gaps, corridor gaps, AdGrid gaps. |
+| `components/mobile/screens/MobileAdGrid.tsx` | `mock_only` | Uses `MOCK_SPONSORS`; commercial surface can misrepresent real sponsors. | Replace with `adgrid_slots`, `sponsors`, `territory_inventory`, and metrics tables. |
+| `components/mobile/screens/MobileCorridors.tsx` | `mock_only` | Uses `MOCK_CORRIDORS`; corridor demand/rate/supply numbers are fake. | Replace with corridor stats view and show fixture fallback only in dev. |
+| `core/integrations/WCSConnector.ts` | `dormant` | Returns true without real WCS order injection. | Feature flag as `partner_pending` until real endpoint/email agreement exists. |
+| `core/integrations/BuildASignConnector.ts` | `dormant` | Mock URL/order IDs; no real fulfillment. | Keep behind marketplace partner flag or replace with approved supplier workflow. |
+| `core/integrations/RapidPayConnector.ts` | `dormant` | Fake payout/card IDs when no API key. | Disable public instant-payout claims until a verified rail is active. |
+| `supabase/_archived_broken_migrations/*` | `archived_broken` | Contains old/broken glossary RPCs; should never be applied blindly. | Keep archived; migrate any good SQL into fresh verified migrations only. |
+| `public/mock/*` | `fixture_ready` | Public mock assets can leak if linked from SEO pages. | Restrict use to dev/demo pages or move to non-public fixtures. |
+| `app/dev/*` | `fixture_ready` | Dev routes should not be indexed or public in production. | Gate by environment or remove from production build. |
+| `.python/Lib/site-packages/*` | `repo_hygiene_debt` | Local environment appears committed; bloats repo and search. | Remove from git and add `.python/` to `.gitignore` if safe. |
+
+## Production rule
+
+A page, API route, or component cannot be marked production-ready if it:
+
+1. Imports or references `MOCK_` arrays outside dev/test files.
+2. Uses fake API keys or fake partner URLs.
+3. Returns success from an external connector without a real network call or queued job.
+4. Uses Pinecone for new vector/search flows.
+5. Shows fake rates, fake sponsor impressions, fake corridor supply, or fake availability without a visible demo label.
+6. Reads from old glossary tables while another live glossary table family is being rendered.
+7. Depends on archived/broken migrations.
+
+## Acceptance tests for future Claude passes
+
+- Every `mock_only` module must either be wired to Supabase, gated behind dev/demo mode, or explicitly removed from production routes.
+- Every commercial surface must have a live-table query path, even if the first fixture dataset is small.
+- Every rateable role must be available as a capability, glossary term, load-board filter, pricing input, and profile badge.
+- Every fixture must be idempotent and safe to run more than once.
+- The mock-to-live audit script must pass before production deploy.

--- a/docs/strategy/money-left-on-table-15x.md
+++ b/docs/strategy/money-left-on-table-15x.md
@@ -1,0 +1,227 @@
+# Haul Command Money Left on the Table + 15X Improvements
+
+_Last updated: 2026-05-01_
+
+This file converts the mock/scaffold audit into revenue and product expansion priorities.
+
+## Immediate money left on the table
+
+### 1. Rateable escort positions are not fully monetized
+
+Missing or under-modeled positions like steerman, fifth car, high pole, drone route survey, bucket truck, wire lift, traffic control, and police coordination should not be buried inside generic pilot-car pricing.
+
+**Money path:** every posted load should generate a role requirement stack and a rate stack.
+
+- Base escort rate
+- Lead car rate
+- Rear/chase car rate
+- High pole premium
+- Steer/tillerman premium
+- Fifth car / extra escort premium
+- Route survey fee
+- Drone route survey fee
+- Bucket truck / wire-lift coordination fee
+- Police escort coordination fee
+- Night/weekend/holiday premium
+- Deadhead, layover, detention, cancellation, rush fees
+
+### 2. Glossary traffic is not yet fully tied to commerce
+
+Every glossary term should route to commercial actions.
+
+Examples:
+
+- `steerman` -> find steer/tillerman providers, post a load requiring steer support, claim steer capability, sponsor steer/tillerman pages.
+- `fifth car` -> explain permit triggers, quote extra escort, sponsor extra escort pages.
+- `drone route survey` -> quote survey, sell partner package, upsell route intelligence report.
+- `bucket truck escort` -> route to utility clearance providers.
+
+### 3. AdGrid has sponsor concepts but mock data
+
+The mobile AdGrid and sponsor cards are still mock-only. Territory sponsorship needs to become sellable inventory.
+
+**Money path:** country -> state/province -> city -> corridor -> glossary term -> service category -> profile page sponsorship.
+
+### 4. Corridor pages have fake supply/demand
+
+Corridors should become paid intelligence and lead-gen pages.
+
+**Money path:** sell corridor sponsor slots, corridor data reports, route survey packages, preferred provider placement, and claim prompts for supply-starved corridors.
+
+### 5. Route survey can be a premium product line
+
+Route survey is not one thing. Split it into:
+
+- Basic route survey
+- Written route survey report
+- High-pole route validation
+- Drone route survey
+- LiDAR / 3D / digital twin survey
+- Bridge/utility conflict review
+- Port/site access review
+- Wind blade / transformer / crane route survey
+
+### 6. Marketplace equipment is dormant
+
+BuildASign-style fulfillment is not wired, but the need is real.
+
+**Money path:** authorized supplier/drop-ship marketplace for banners, flags, beacons, radios, height poles, reflective tape, PPE, dashcams, GPS trackers, and install referrals.
+
+### 7. Supabase vector/RAG replacement is not complete
+
+Old Pinecone code remains. Supabase should power semantic role/alias matching, glossary retrieval, profile matching, and quote intent classification.
+
+**Money path:** better matching -> more claims, more quotes, more broker confidence, more paid data products.
+
+### 8. Country-local equivalents are not complete enough
+
+Terms like Batedor, BF3/BF4, Voiture Pilote, Scorta Tecnica, Load Pilot, OSOM, abnormal load, ODC, and convoi exceptionnel are started, but not enough for all 120 countries.
+
+**Money path:** country-local SEO + trust + claim conversion.
+
+## 15X improvements
+
+### 1. Requirement Stack Engine
+
+Build a requirement engine that takes a load and outputs:
+
+- Required permits
+- Required escort positions
+- Optional but recommended positions
+- Rate categories
+- Hazard modifiers
+- route survey need
+- utility/police/traffic-control need
+- glossary explanations
+- provider matching filters
+
+This turns a load post into a monetizable checklist.
+
+### 2. Role-to-Revenue Matrix
+
+Every role/capability gets:
+
+- glossary page
+- profile badge
+- claim prompt
+- load-board filter
+- quote input
+- pricing category
+- sponsor inventory
+- training module
+- country aliases
+- internal links
+
+### 3. Commercial Glossary Pages
+
+Glossary pages should not be informational dead ends. Each should include:
+
+- definition
+- field usage
+- when it is required
+- what it costs
+- related hazards
+- related permits
+- related tools
+- find providers
+- post a load
+- claim capability
+- sponsor this term
+- country equivalents
+
+### 4. Corridor Intelligence Products
+
+Create public/free and paid/private layers:
+
+Free:
+- overview
+- common hazards
+- required escorts
+- glossary links
+- provider cards
+
+Paid:
+- demand history
+- rate ranges
+- supply gaps
+- route survey warnings
+- sponsor heatmaps
+- operator availability trends
+
+### 5. Fixture-to-Live Enforcement
+
+Every mock UI should have a fixture mode and a live mode.
+
+- dev/demo pages can use fixtures
+- production pages must use Supabase/API
+- CI should fail when `MOCK_` arrays appear in production files
+
+### 6. Claim Machine Upgrade
+
+When a term/profile/capability is missing, create a claim or partner prompt.
+
+Examples:
+
+- Search for `steerman near me` with no results -> recruit/claim steer-capable operators.
+- Search for `drone route survey` with no results -> partner application for drone surveyors.
+- Corridor has load demand but no high-pole supply -> outreach to high-pole operators.
+
+### 7. Data Monetization Layer
+
+Repeated observations should be preserved, not deleted.
+
+Monetizable datasets:
+
+- corridor demand
+- rate observations
+- role requirement frequency
+- fifth-car requirement frequency
+- high-pole requirement frequency
+- police escort requirement frequency
+- route survey triggers
+- country/local terminology usage
+- claim conversion by role/category
+
+### 8. Country-Local Expansion Guardrail
+
+Every new role term needs:
+
+- canonical English label
+- local country aliases
+- legal/regulatory notes where known
+- local profile/service category
+- local search keywords
+- local sponsor surface
+- local glossary page
+
+### 9. No Dead-End Rule
+
+No page should end with only information.
+
+Every page must offer at least one of:
+
+- find provider
+- post load
+- request quote
+- claim listing
+- add capability
+- sponsor territory
+- apply as partner
+- buy equipment
+- view training
+- download data/report
+
+### 10. Money-path scoring
+
+Every feature should get a score from 0-100 across:
+
+- claim conversion
+- quote conversion
+- sponsor revenue
+- data monetization
+- SEO/AEO traffic
+- marketplace revenue
+- trust/review value
+- global localization value
+
+Anything below 60 gets parked unless it supports compliance or trust.

--- a/scripts/qa/mock_to_live_audit.mjs
+++ b/scripts/qa/mock_to_live_audit.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+/**
+ * Haul Command Mock-to-Live Audit
+ *
+ * Fails production readiness if high-risk production files still contain
+ * mock-only patterns, fake credentials, old Pinecone wiring, or demo arrays.
+ * This is intentionally lightweight and dependency-free so Claude/CI can run it.
+ */
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const ROOT = process.cwd();
+
+const CHECKS = [
+  {
+    file: 'app/api/quote/route.ts',
+    status: 'mock_only',
+    reason: 'Quote pricing must not use hardcoded example rates or mock currency.',
+    patterns: [/Example dynamic pricing rules/i, /mock/i, /baseRatePerMile\s*=\s*countryCode/i]
+  },
+  {
+    file: 'lib/ai/vector-layer.ts',
+    status: 'deprecated',
+    reason: 'Vector search must be Supabase-first. Pinecone/mock vector returns are deprecated.',
+    patterns: [/Pinecone/i, /mock-key/i, /mock-uuid/i, /simulated embeddings/i]
+  },
+  {
+    file: 'components/command/GlobalDensityMap.tsx',
+    status: 'mock_only',
+    reason: 'Global density map must not rely on mock Mapbox token or prop-only markers for production.',
+    patterns: [/architectural scaffolding/i, /mock-user/i, /markers\s*=\s*\[\]/i]
+  },
+  {
+    file: 'components/mobile/screens/MobileAdGrid.tsx',
+    status: 'mock_only',
+    reason: 'AdGrid must use live sponsor/slot inventory or dev-only fixtures.',
+    patterns: [/MOCK_SPONSORS/i]
+  },
+  {
+    file: 'components/mobile/screens/MobileCorridors.tsx',
+    status: 'mock_only',
+    reason: 'Corridors must use live corridor stats or dev-only fixtures.',
+    patterns: [/MOCK_CORRIDORS/i]
+  },
+  {
+    file: 'core/integrations/WCSConnector.ts',
+    status: 'dormant',
+    reason: 'WCS connector returns success without a real network call.',
+    patterns: [/Mock/i, /return true/i, /orders@wcspermits\.com/i]
+  },
+  {
+    file: 'core/integrations/BuildASignConnector.ts',
+    status: 'dormant',
+    reason: 'BuildASign connector uses mock URL/order behavior.',
+    patterns: [/Mock URL/i, /Connector is dormant/i, /ORD-\$\{Date\.now\(\)\}/i]
+  },
+  {
+    file: 'core/integrations/RapidPayConnector.ts',
+    status: 'dormant',
+    reason: 'RapidPay connector uses mock payout/card behavior.',
+    patterns: [/Mock API Call/i, /CARD-\$\{provider\.id/i, /Connector.*dormant/i]
+  }
+];
+
+let failures = [];
+
+for (const check of CHECKS) {
+  const abs = resolve(ROOT, check.file);
+  if (!existsSync(abs)) {
+    failures.push({ ...check, found: 'missing_file' });
+    continue;
+  }
+  const text = readFileSync(abs, 'utf8');
+  const hits = check.patterns.filter((p) => p.test(text)).map(String);
+  if (hits.length) {
+    failures.push({ ...check, found: hits });
+  }
+}
+
+if (failures.length) {
+  console.error('\n❌ Mock-to-live audit failed. Production-risk scaffolding remains:\n');
+  for (const f of failures) {
+    console.error(`- ${f.file} [${f.status}]`);
+    console.error(`  ${f.reason}`);
+    console.error(`  Hits: ${Array.isArray(f.found) ? f.found.join(', ') : f.found}`);
+  }
+  console.error('\nFix by wiring to live Supabase/API data, gating behind dev-only mode, or removing from production routes.\n');
+  process.exit(1);
+}
+
+console.log('✅ Mock-to-live audit passed. No high-risk mock patterns found.');

--- a/supabase/fixtures/hc_position_taxonomy_seed.sql
+++ b/supabase/fixtures/hc_position_taxonomy_seed.sql
@@ -1,0 +1,223 @@
+-- ============================================================================
+-- Haul Command Position / Capability / Hazard / Rate Fixture Seed
+-- Purpose: make field-grade roles concrete before wiring production pricing,
+-- glossary, load-board filters, profile capabilities, and quote logic.
+-- Safe to run repeatedly.
+-- ============================================================================
+
+create extension if not exists pgcrypto;
+
+create table if not exists public.hc_position_taxonomy (
+  id uuid primary key default gen_random_uuid(),
+  slug text not null unique,
+  canonical_label text not null,
+  role_family text not null,
+  position_type text not null,
+  public_account_role text,
+  marketplace_visible boolean not null default true,
+  glossary_required boolean not null default true,
+  profile_capability_required boolean not null default true,
+  load_board_filter_required boolean not null default true,
+  rate_category_slug text,
+  requires_special_skill boolean not null default false,
+  country_scope text[] not null default array['US'],
+  hazard_triggers text[] not null default '{}',
+  related_glossary_slugs text[] not null default '{}',
+  definition_seed text not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.hc_position_aliases (
+  id uuid primary key default gen_random_uuid(),
+  position_slug text not null references public.hc_position_taxonomy(slug) on delete cascade,
+  alias text not null,
+  alias_type text not null default 'field_term',
+  country_code text,
+  region_code text,
+  language_code text default 'en',
+  is_preferred boolean not null default false,
+  created_at timestamptz not null default now(),
+  unique(position_slug, lower(alias), coalesce(country_code,''), coalesce(region_code,''), coalesce(language_code,''))
+);
+
+create table if not exists public.hc_hazard_modifiers (
+  id uuid primary key default gen_random_uuid(),
+  slug text not null unique,
+  label text not null,
+  hazard_family text not null,
+  definition_seed text not null,
+  likely_required_positions text[] not null default '{}',
+  likely_rate_categories text[] not null default '{}',
+  country_scope text[] not null default array['US'],
+  marketplace_filter_required boolean not null default true,
+  pricing_modifier_required boolean not null default true,
+  glossary_required boolean not null default true,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.hc_rate_categories (
+  id uuid primary key default gen_random_uuid(),
+  slug text not null unique,
+  label text not null,
+  rate_family text not null,
+  unit text not null,
+  definition_seed text not null,
+  applies_to_positions text[] not null default '{}',
+  applies_to_hazards text[] not null default '{}',
+  country_scope text[] not null default array['US'],
+  requires_live_market_data boolean not null default true,
+  created_at timestamptz not null default now()
+);
+
+-- Core paid move positions and high-value capability positions.
+insert into public.hc_position_taxonomy
+(slug, canonical_label, role_family, position_type, public_account_role, rate_category_slug, requires_special_skill, country_scope, hazard_triggers, related_glossary_slugs, definition_seed)
+values
+('pilot_car_operator','Pilot Car Operator','escort_operations','public_role','pilot_car_escort','escort_base_rate',false,array['US','CA'],'{}',array['pilot-car','escort-vehicle'],'A pilot car operator drives an escort vehicle that accompanies an oversize or overweight load to warn traffic, communicate hazards, and support safe movement.'),
+('lead_car','Lead Car','escort_operations','paid_move_position','pilot_car_escort','lead_car_rate',true,array['US','CA'],'{oncoming_traffic,route_clearance,high_pole_required}',array['pilot-car','lead-car','height-pole'],'The lead car travels ahead of the load to warn oncoming traffic, verify route conditions, communicate hazards, and often carry a height pole for tall loads.'),
+('rear_escort','Rear Escort','escort_operations','paid_move_position','pilot_car_escort','rear_escort_rate',true,array['US','CA'],'{rear_overhang,traffic_merge_risk,multiple_escort_cars_required}',array['chase-car','rear-escort'],'The rear escort follows the oversize load to protect the back of the movement, warn traffic from behind, and support lane changes or turns.'),
+('high_pole_escort','High Pole Escort','escort_operations','paid_move_position','pilot_car_escort','high_pole_rate',true,array['US','CA'],'{over_legal_height,low_bridge,overhead_wires,high_pole_required}',array['height-pole','high-pole-escort','bridge-clearance'],'A high pole escort uses a calibrated height pole on the lead vehicle to check overhead obstructions before the load reaches them.'),
+('steer_operator','Steer Operator','escort_operations','paid_move_position','pilot_car_escort','steer_rate',true,array['US','CA','AU','GB'],'{extreme_length,steerable_trailer,rear_steer_required,tight_turn_radius,urban_route,bridge_crossing}',array['steerman','steersman','tillerman','rear-steer-operator'],'A steer operator assists a long or specialized trailer through turns and tight route geometry, often coordinating rear steer or trailer articulation.'),
+('supplemental_escort_vehicle','Supplemental Escort Vehicle','escort_operations','paid_move_position','pilot_car_escort','extra_escort_rate',true,array['US','CA'],'{multiple_escort_cars_required,fifth_car_required,superload}',array['fifth-car','extra-escort-car'],'A supplemental escort vehicle is an additional escort beyond the normal lead/rear setup, often called a fifth car when permit conditions or hazards require more coverage.'),
+('route_surveyor','Route Surveyor','route_intelligence','paid_service','route_survey_provider','route_survey_rate',true,array['US','CA','AU','GB','NZ'],'{route_survey_required,superload,low_bridge,narrow_bridge,railroad_crossing,urban_route}',array['route-survey','route-check','clearance'],'A route surveyor inspects the planned route before a move to identify clearance, weight, turn-radius, utility, construction, and permit problems.'),
+('drone_route_surveyor','Drone Route Surveyor','route_intelligence','paid_service','route_survey_provider','drone_route_survey_rate',true,array['US','CA','AU','GB'],'{drone_survey_required,overhead_wires,bridge_clearance,turn_radius,construction_zone}',array['route-survey','drone-route-survey','overhead-obstruction-survey'],'A drone route surveyor uses UAV imagery or video to inspect overhead, turn, access, and obstruction issues before or during a heavy haul move.'),
+('lidar_route_survey_provider','LiDAR Route Survey Provider','route_intelligence','paid_service','route_survey_provider','technical_survey_rate',true,array['US','CA','AU','GB','DE'],'{engineering_review_required,bridge_analysis_required,extreme_height,extreme_length}',array['lidar-route-survey','digital-twin-route-modeler'],'A LiDAR route survey provider captures precise 3D route geometry for clearance, swept-path, and digital-twin analysis.'),
+('traffic_control_escort','Traffic Control Escort','traffic_control','paid_move_position','traffic_control_provider','traffic_control_rate',true,array['US','CA','AU','GB'],'{traffic_control_required,urban_route,intersection_control,road_closure_required}',array['traffic-control','flagger'],'A traffic control escort manages traffic around the load, including intersection control, temporary stops, lane closures, and route protection.'),
+('police_escort_coordinator','Police Escort Coordinator','traffic_control','paid_service','traffic_control_provider','police_coordination_rate',true,array['US','CA','AU','GB','AE'],'{police_escort_required,superload,urban_route,law_enforcement_required}',array['police-escort','law-enforcement-escort'],'A police escort coordinator arranges required law-enforcement support for oversize or superload movements.'),
+('bucket_truck_provider','Bucket Truck Provider','utility_clearance','paid_service','utility_clearance_provider','bucket_truck_rate',true,array['US','CA'],'{bucket_truck_required,overhead_wires,wire_lifting_needed}',array['bucket-truck-escort','utility-coordination'],'A bucket truck provider supplies elevated work equipment and crews to lift, protect, or manage overhead lines and obstructions for tall loads.'),
+('overhead_wire_lifter','Overhead Wire Lifter','utility_clearance','paid_service','utility_clearance_provider','wire_lift_rate',true,array['US','CA'],'{wire_lifting_needed,overhead_wires,over_legal_height}',array['overhead-wires','utility-coordination'],'An overhead wire lifter coordinates or performs temporary lifting or management of wires so tall loads can pass safely.'),
+('permit_service_company','Permit Service Company','permit_compliance','public_role','permit_provider','permit_service_rate',true,array['US','CA','AU','GB','NZ'],'{permit_required,superload,cross_border_move}',array['oversize-permit','overweight-permit'],'A permit service company prepares and files oversize, overweight, superload, route, and jurisdiction-specific permits.'),
+('escort_dispatcher','Escort Dispatcher','broker_dispatch','paid_service','broker_dispatcher','dispatch_rate',false,array['US','CA'],'{rush_move,multiple_escort_cars_required,coverage_gap}',array['dispatching','pilot-car-dispatcher'],'An escort dispatcher matches pilot cars, route surveyors, traffic control, and support providers to loads and route requirements.'),
+('heavy_haul_broker','Heavy Haul Broker','broker_dispatch','public_role','broker','broker_margin',false,array['US','CA','AU','GB'],'{load_posted,quote_needed,carrier_needed}',array['freight-broker','heavy-haul'],'A heavy haul broker connects shippers, carriers, pilot cars, permit services, and support providers for specialized loads.'),
+('oversize_load_driver','Oversize Load Driver','carrier_operations','public_role','carrier_driver','driver_rate',true,array['US','CA','AU','GB'],'{over_legal_width,over_legal_height,over_legal_length,superload}',array['oversize-load','heavy-haul-driver'],'An oversize load driver operates the truck or tractor moving a permitted oversize or overweight load.'),
+('rigging_supervisor','Rigging Supervisor','site_rigging','paid_service','site_support_provider','rigging_rate',true,array['US','CA','AU','GB'],'{loading_complexity,high_value_load,crane_required}',array['rigging','load-securement'],'A rigging supervisor plans and oversees loading, securing, lifting, and site movement for heavy or complex cargo.'),
+('pilot_car_upfitter','Pilot Car Upfitter','equipment_marketplace','public_role','equipment_installer','installer_rate',true,array['US','CA','AU','GB'],'{equipment_fail,certified_escort_required}',array['pilot-car-equipment','height-pole-kit'],'A pilot car upfitter installs lights, signs, radios, height poles, flags, GPS, dashcams, and other required escort vehicle equipment.'),
+('secure_staging_yard_provider','Secure Staging Yard Provider','route_support_infrastructure','paid_service','infrastructure_provider','staging_yard_rate',false,array['US','CA','AU','GB'],'{staging_needed,superload,night_move,port_entry}',array['staging-yard','oversize-parking'],'A secure staging yard provider offers space to stage loads, escorts, equipment, or crews before, during, or after a heavy haul move.')
+on conflict (slug) do update set
+  canonical_label = excluded.canonical_label,
+  role_family = excluded.role_family,
+  position_type = excluded.position_type,
+  public_account_role = excluded.public_account_role,
+  rate_category_slug = excluded.rate_category_slug,
+  requires_special_skill = excluded.requires_special_skill,
+  country_scope = excluded.country_scope,
+  hazard_triggers = excluded.hazard_triggers,
+  related_glossary_slugs = excluded.related_glossary_slugs,
+  definition_seed = excluded.definition_seed,
+  updated_at = now();
+
+insert into public.hc_position_aliases (position_slug, alias, alias_type, country_code, language_code, is_preferred) values
+('pilot_car_operator','Pilot Car Operator','canonical','US','en',true),
+('pilot_car_operator','P/EVO','acronym','US','en',false),
+('pilot_car_operator','Pilot/Escort Vehicle Operator','formal','US','en',false),
+('lead_car','Lead Car','field_term','US','en',true),
+('lead_car','Lead Pilot','field_term','US','en',false),
+('lead_car','Front Escort','field_term','US','en',false),
+('rear_escort','Chase Car','field_term','US','en',true),
+('rear_escort','Rear Car','field_term','US','en',false),
+('rear_escort','Tail Escort','field_term','US','en',false),
+('high_pole_escort','High Pole','field_term','US','en',true),
+('high_pole_escort','Height Pole Operator','field_term','US','en',false),
+('steer_operator','Steerman','field_term','US','en',true),
+('steer_operator','Steersman','field_term','US','en',false),
+('steer_operator','Tillerman','field_term','US','en',false),
+('steer_operator','Steer Car','field_term','US','en',false),
+('steer_operator','Rear Steer Operator','field_term','US','en',false),
+('supplemental_escort_vehicle','Fifth Car','field_term','US','en',true),
+('supplemental_escort_vehicle','Extra Escort Car','field_term','US','en',false),
+('supplemental_escort_vehicle','Supplemental Escort','field_term','US','en',false),
+('drone_route_surveyor','Drone Route Survey','service_alias','US','en',true),
+('drone_route_surveyor','UAV Route Survey','service_alias','US','en',false),
+('lidar_route_survey_provider','LiDAR Route Survey','service_alias','US','en',true),
+('bucket_truck_provider','Bucket Truck Escort','field_term','US','en',true),
+('overhead_wire_lifter','Wire Lift Crew','field_term','US','en',true),
+('permit_service_company','Permit Runner','field_term','US','en',false),
+('heavy_haul_broker','Oversize Load Broker','field_term','US','en',false)
+on conflict do nothing;
+
+insert into public.hc_rate_categories
+(slug, label, rate_family, unit, definition_seed, applies_to_positions, applies_to_hazards, country_scope, requires_live_market_data)
+values
+('escort_base_rate','Escort Base Rate','escort','per_mile_or_day','Base pricing for standard pilot car escort service before specialty modifiers.',array['pilot_car_operator'],array['over_legal_width','over_legal_length'],array['US','CA'],true),
+('lead_car_rate','Lead Car Rate','escort','per_mile_or_day','Rate for the lead escort vehicle traveling ahead of the load.',array['lead_car'],array['route_clearance','oncoming_traffic'],array['US','CA'],true),
+('rear_escort_rate','Rear Escort Rate','escort','per_mile_or_day','Rate for the rear/chase escort vehicle protecting the back of the movement.',array['rear_escort'],array['rear_overhang','traffic_merge_risk'],array['US','CA'],true),
+('high_pole_rate','High Pole Rate','escort_specialty','per_mile_or_day','Premium rate for high pole/height pole escort service.',array['high_pole_escort'],array['over_legal_height','low_bridge','overhead_wires'],array['US','CA'],true),
+('steer_rate','Steer / Steerman Rate','escort_specialty','per_mile_or_day','Premium rate for steer/tillerman/rear-steer support.',array['steer_operator'],array['extreme_length','tight_turn_radius','rear_steer_required'],array['US','CA'],true),
+('extra_escort_rate','Fifth Car / Extra Escort Rate','escort_specialty','per_mile_or_day','Rate for extra/supplemental escort vehicles beyond the standard formation.',array['supplemental_escort_vehicle'],array['fifth_car_required','multiple_escort_cars_required'],array['US','CA'],true),
+('route_survey_rate','Route Survey Rate','survey','flat_or_hourly','Rate for route survey service and written route report.',array['route_surveyor'],array['route_survey_required','superload'],array['US','CA'],true),
+('drone_route_survey_rate','Drone Route Survey Rate','survey_technical','flat_or_hourly','Rate for drone/UAV route inspection, imagery, and clearance review.',array['drone_route_surveyor'],array['drone_survey_required','overhead_wires'],array['US','CA'],true),
+('technical_survey_rate','Technical Survey Rate','survey_technical','flat_or_hourly','Rate for LiDAR, photogrammetry, 360-camera, or digital-twin route survey work.',array['lidar_route_survey_provider'],array['engineering_review_required','bridge_analysis_required'],array['US','CA','DE'],true),
+('traffic_control_rate','Traffic Control Rate','traffic_control','hourly_or_day','Rate for traffic control escorts, flaggers, lane closures, and intersection control.',array['traffic_control_escort'],array['traffic_control_required','road_closure_required'],array['US','CA'],true),
+('police_coordination_rate','Police Escort Coordination Rate','traffic_control','flat_or_admin','Administrative/service rate for arranging required police or law enforcement escorts.',array['police_escort_coordinator'],array['police_escort_required'],array['US','CA','AE'],true),
+('bucket_truck_rate','Bucket Truck Rate','utility_clearance','hourly_or_day','Rate for bucket truck and elevated utility clearance support.',array['bucket_truck_provider'],array['bucket_truck_required','wire_lifting_needed'],array['US','CA'],true),
+('wire_lift_rate','Wire Lift Rate','utility_clearance','hourly_or_event','Rate for overhead wire lifting, utility crew coordination, and obstruction clearance.',array['overhead_wire_lifter'],array['wire_lifting_needed','overhead_wires'],array['US','CA'],true),
+('deadhead_rate','Deadhead Mileage','accessorial','per_mile','Mileage rate for unpaid travel to pickup, from dropoff, or between disconnected moves.',array['pilot_car_operator','lead_car','rear_escort'],array['remote_origin','coverage_gap'],array['US','CA'],true),
+('layover_detention_rate','Layover / Detention Rate','accessorial','hourly_or_day','Rate for waiting time, overnight hold, permit delays, weather holds, or shipper-caused delay.',array['pilot_car_operator','route_surveyor','traffic_control_escort'],array['wait_time','weather_hold','permit_delay'],array['US','CA'],true)
+on conflict (slug) do update set
+  label = excluded.label,
+  rate_family = excluded.rate_family,
+  unit = excluded.unit,
+  definition_seed = excluded.definition_seed,
+  applies_to_positions = excluded.applies_to_positions,
+  applies_to_hazards = excluded.applies_to_hazards,
+  country_scope = excluded.country_scope,
+  requires_live_market_data = excluded.requires_live_market_data;
+
+insert into public.hc_hazard_modifiers
+(slug, label, hazard_family, definition_seed, likely_required_positions, likely_rate_categories, country_scope)
+values
+('over_legal_width','Over Legal Width','dimension','The load exceeds standard legal width and may trigger escort, signage, permit, and route restrictions.',array['lead_car','rear_escort'],array['escort_base_rate','lead_car_rate','rear_escort_rate'],array['US','CA']),
+('over_legal_height','Over Legal Height','dimension','The load exceeds legal height and may require height pole escort, route survey, or utility coordination.',array['high_pole_escort','route_surveyor'],array['high_pole_rate','route_survey_rate'],array['US','CA']),
+('extreme_length','Extreme Length','dimension','The load or combination is long enough to create turning, sweep, bridge, or escort complexity.',array['steer_operator','supplemental_escort_vehicle','route_surveyor'],array['steer_rate','extra_escort_rate','route_survey_rate'],array['US','CA']),
+('superload','Superload','permit_class','The movement exceeds ordinary oversize/overweight permit thresholds and requires special review, escorts, survey, or authorities.',array['route_surveyor','high_pole_escort','supplemental_escort_vehicle','police_escort_coordinator'],array['route_survey_rate','high_pole_rate','extra_escort_rate','police_coordination_rate'],array['US','CA']),
+('low_bridge','Low Bridge','route_clearance','A bridge or overhead structure may not provide sufficient clearance for the load.',array['high_pole_escort','route_surveyor','drone_route_surveyor'],array['high_pole_rate','route_survey_rate','drone_route_survey_rate'],array['US','CA']),
+('overhead_wires','Overhead Wires','route_clearance','Power, telecom, cable, or signal wires may interfere with a tall load.',array['high_pole_escort','bucket_truck_provider','overhead_wire_lifter','drone_route_surveyor'],array['high_pole_rate','bucket_truck_rate','wire_lift_rate','drone_route_survey_rate'],array['US','CA']),
+('railroad_crossing','Railroad Crossing','route_clearance','A rail crossing may create grade, clearance, notification, or high-centering risk.',array['route_surveyor','rear_escort','traffic_control_escort'],array['route_survey_rate','traffic_control_rate'],array['US','CA']),
+('urban_route','Urban Route','route_complexity','Dense urban routes may require intersection control, police, extra escorts, or night movement.',array['traffic_control_escort','police_escort_coordinator','supplemental_escort_vehicle'],array['traffic_control_rate','police_coordination_rate','extra_escort_rate'],array['US','CA']),
+('fifth_car_required','Fifth Car Required','escort_formation','Permit, route, or hazard conditions require an additional escort vehicle beyond normal formation.',array['supplemental_escort_vehicle'],array['extra_escort_rate'],array['US','CA']),
+('steer_tillerman_required','Steer / Tillerman Required','escort_formation','The move requires steer/tillerman support for trailer articulation, tight turns, or rear steer.',array['steer_operator'],array['steer_rate'],array['US','CA']),
+('drone_survey_required','Drone Survey Required','survey','The route needs aerial/drone inspection for clearance, access, construction, wires, or approach geometry.',array['drone_route_surveyor'],array['drone_route_survey_rate'],array['US','CA']),
+('police_escort_required','Police Escort Required','authority','Law enforcement escort or traffic authority support is required by permit, jurisdiction, or hazard.',array['police_escort_coordinator'],array['police_coordination_rate'],array['US','CA','AE']),
+('bucket_truck_required','Bucket Truck Required','utility_clearance','A bucket truck is needed to manage overhead lines, signs, signals, or other elevated obstructions.',array['bucket_truck_provider'],array['bucket_truck_rate'],array['US','CA']),
+('night_move','Night Move','timing','The move occurs at night and may require extra lighting, escorts, approvals, or premiums.',array['pilot_car_operator','traffic_control_escort'],array['escort_base_rate','traffic_control_rate'],array['US','CA']),
+('port_twic_required','Port / TWIC Required','security','Port access or TWIC/security credentialing is required for the move.',array['pilot_car_operator','heavy_haul_broker'],array['escort_base_rate'],array['US'])
+on conflict (slug) do update set
+  label = excluded.label,
+  hazard_family = excluded.hazard_family,
+  definition_seed = excluded.definition_seed,
+  likely_required_positions = excluded.likely_required_positions,
+  likely_rate_categories = excluded.likely_rate_categories,
+  country_scope = excluded.country_scope;
+
+-- Optional bridge into the older glossary_terms model if present.
+do $$
+begin
+  if to_regclass('public.glossary_terms') is not null then
+    insert into public.glossary_terms
+      (slug, term, short_definition, long_definition, category, synonyms, related_slugs, tags, jurisdiction, published, noindex, priority)
+    select
+      p.slug,
+      p.canonical_label,
+      left(p.definition_seed, 240),
+      p.definition_seed,
+      'Roles & Positions',
+      coalesce((select array_agg(a.alias order by a.is_preferred desc, a.alias) from public.hc_position_aliases a where a.position_slug = p.slug), '{}'),
+      p.related_glossary_slugs,
+      array[p.role_family, p.position_type, coalesce(p.rate_category_slug,'no_rate_category')],
+      'global',
+      true,
+      false,
+      90
+    from public.hc_position_taxonomy p
+    on conflict (slug) do update set
+      term = excluded.term,
+      short_definition = excluded.short_definition,
+      long_definition = excluded.long_definition,
+      category = excluded.category,
+      synonyms = excluded.synonyms,
+      related_slugs = excluded.related_slugs,
+      tags = excluded.tags,
+      updated_at = now();
+  end if;
+end $$;


### PR DESCRIPTION
## Summary

Adds a fixture/enforcement package to turn the scaffold audit into actionable repo assets.

### Added

- `docs/audits/mock-to-live-registry.md`
  - Registry of mock-only, dormant, deprecated, archived, and partial systems.
  - Production rules for fake rates, fake sponsors, Pinecone leftovers, dev/mock routes, and dormant connectors.

- `supabase/fixtures/hc_position_taxonomy_seed.sql`
  - Creates and seeds:
    - `hc_position_taxonomy`
    - `hc_position_aliases`
    - `hc_hazard_modifiers`
    - `hc_rate_categories`
  - Covers missing high-value terms/capabilities including:
    - steerman / steersman / tillerman
    - fifth car / extra escort / supplemental escort
    - high pole / height pole
    - drone route survey / UAV survey
    - LiDAR route survey
    - bucket truck escort
    - overhead wire lifter / wire lift crew
    - traffic control escort
    - police escort coordinator
    - rate categories and hazard triggers
  - Bridges into `glossary_terms` if that older glossary table exists.

- `scripts/qa/mock_to_live_audit.mjs`
  - Lightweight QA script that fails when high-risk production files still contain mock-only patterns.

- `docs/strategy/money-left-on-table-15x.md`
  - Money-left-on-table analysis and 15X improvements around role-to-revenue, route surveys, AdGrid, corridor intelligence, glossary commerce, and data products.

## Why

The repo has strong architecture, but several production-looking surfaces are still mock-only or dormant:

- quote pricing
- Pinecone/vector layer
- GlobalDensityMap
- MobileAdGrid
- MobileCorridors
- WCS / BuildASign / RapidPay connectors
- archived/broken glossary RPCs

This PR does not pretend those integrations are live. It creates the fixture contract and enforcement trail needed to wire them correctly.

## Next steps after merge

1. Run the fixture SQL in Supabase dev/staging.
2. Decide canonical glossary system: `glossary_terms` vs `glo_terms`.
3. Wire quote API to `hc_rate_categories`, `hc_position_taxonomy`, and `hc_hazard_modifiers`.
4. Replace Pinecone vector path with Supabase search/vector RPC.
5. Replace MobileAdGrid and MobileCorridors mock arrays with Supabase views.
6. Gate dormant partner connectors behind feature flags.
