### PR TITLE
chore: add 120-country drift CI guard and agent guardrail doc

### DIFF
--- a/.github/workflows/country-drift.yml
+++ b/.github/workflows/country-drift.yml
@@ -1,0 +1,26 @@
+name: 120-Country Drift Guardrail
+
+# Prevents stale "57 countries" scope drift from re-entering live source
+# paths (app/, components/, lib/, pages/). Historical artifacts in
+# migrations and planning docs are intentionally not scanned.
+#
+# See CLAUDE.md > "120-Country Standard (Never Drift Back)" and
+# scripts/check-country-drift.js for the rule itself.
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  check-country-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Run country-drift checker
+        run: node scripts/check-country-drift.js

--- a/app/admin/batch-jobs/page.tsx
+++ b/app/admin/batch-jobs/page.tsx
@@ -76,7 +76,7 @@ const BATCH_JOBS = [
   },
   {
     id: 'regulations',
-    name: '57-Country Regulation Summaries',
+    name: '120-Country Regulation Summaries',
     description: 'Gemini + Google Search generates accurate oversize load regulation pages for all 120 countries.',
     endpoint: '/api/admin/batch/corridors',
     method: 'POST',

--- a/app/admin/dashboards/data-products/page.tsx
+++ b/app/admin/dashboards/data-products/page.tsx
@@ -108,7 +108,7 @@ export default function DataProductsDashboard() {
 
             {activeTab === 'pricing' && (
                 <div style={{ padding: 24, borderRadius: 16, border: '1px solid rgba(255,255,255,0.06)', background: 'rgba(255,255,255,0.02)', marginBottom: 24 }}>
-                    <h2 style={{ fontSize: 16, fontWeight: 800, color: '#fff', marginBottom: 16 }}>57-Country Pricing by Tier</h2>
+                    <h2 style={{ fontSize: 16, fontWeight: 800, color: '#fff', marginBottom: 16 }}>120-Country Pricing by Tier</h2>
                     {Object.entries({ A: ['US','CA','AU','GB','NZ','ZA','DE','NL','AE','BR'], B: ['IE','SE','NO','DK','FI','BE','AT','CH','ES','FR','IT','PT','SA','QA','MX','IN','ID','TH'], C: ['PL','CZ','SK','HU','SI','EE','LV','LT','HR','RO','BG','GR','TR','KW','OM','BH','SG','MY','JP','KR','CL','AR','CO','PE','VN','PH'], D: ['UY','PA','CR'] }).map(([tier, countries]) => {
                         const meta = TIER_LABELS[tier];
                         const multiplier = tier === 'A' ? 1.0 : tier === 'B' ? 0.65 : tier === 'C' ? 0.40 : 0.25;

--- a/app/api/treasury/nowpayments-withdraw/route.ts
+++ b/app/api/treasury/nowpayments-withdraw/route.ts
@@ -10,7 +10,7 @@ import { createClient } from "@/lib/supabase/server";
  * 1. LEGAL (KYC & OFAC): 
  *    - In the US, UK, EU, sending unregulated crypto without KYC is money laundering.
  *    - We enforce a "kyc_status = verified" requirement before honoring the API.
- *    - 57-Country Check: We map the operator's geo against the `marketplace_liability_profile`.
+ *    - 120-Country Check: We map the operator's geo against the `marketplace_liability_profile`.
  * 
  * 2. THE RED (LIQUIDITY & GAS PROTECTION):
  *    - A broker can chargeback on Stripe up to 120 days later. Crypto is irreversible.

--- a/docs/agent-guardrails.md
+++ b/docs/agent-guardrails.md
@@ -1,0 +1,150 @@
+# Agent Guardrails — Read Before Touching Production Surfaces
+
+This is an orientation map for Claude Code (and any other coding agent) working
+in this repository. It does not replace `CLAUDE.md` — it points to the highest-
+risk areas where agents have historically caused regressions, and gives the
+exact source of truth for each.
+
+If a note here ever conflicts with `CLAUDE.md`, **`CLAUDE.md` wins.** This file
+is supplementary.
+
+---
+
+## 1. 120-Country Scope (Never Drift Back to 57)
+
+Haul Command serves **120 countries**, tiered A–E. Any "57 countries" / "57-country"
+reference in shipped UI, server libs, or components is stale legacy drift.
+
+- Rule: see `CLAUDE.md` > "120-Country Standard (Never Drift Back)"
+- Single source of truth for live counts: `lib/server/global-stats.ts` (`getGlobalStats`)
+- CI guard: `.github/workflows/country-drift.yml`
+- Local scan: `npm run lint:country-drift`
+- Scanner source + allowlist: `scripts/check-country-drift.js`
+
+The scanner deliberately scopes to `app/`, `components/`, `lib/`, `pages/` and
+ignores historical SQL migrations and planning docs. If a hit is intentional
+historical content, allowlist the path in the script with a one-line reason
+rather than weakening the regex.
+
+---
+
+## 2. No Fake Live Stats
+
+Never display fabricated, rounded-up, or zeroed-out platform numbers as if they
+were live. The trust cost with industry professionals is permanent.
+
+- Source of truth: `lib/server/global-stats.ts`
+- The fallback object in that file is intentionally honest. Do not inflate it.
+- If a Supabase query returns zero, hide the surface or label it honestly
+  ("Seeded Corridors", "Listed Operators") — do not show "0 active" alongside
+  marketing copy that claims "7,712+ verified."
+
+When in doubt, prefer hiding a number to inventing one.
+
+---
+
+## 3. Outreach Policy (Hard Stop — Voice Only, 90-Day Seasoning)
+
+No email, SMS, or voice outreach to operators is permitted unless **all**
+conditions hold:
+
+- Profile age ≥ 90 days since first seen
+- Authority score ≥ 40
+- Channel is **LiveKit voice** (no email, no SMS, ever)
+
+These are enforced at the database layer via the trigger
+`trg_claim_outreach_seasoning` and the `hc_policy` keys:
+
+- `claim.seasoning_days_minimum = 90`
+- `claim.outreach.requires_authority_score = 40`
+- `claim.outreach.no_email_no_sms = true`
+
+Before scheduling any outreach in code, query `hc_policy` and respect what it
+returns at runtime — do not hard-code thresholds in TypeScript. The Supabase
+trigger is the last line of defense; treat it as a guard, not a substitute for
+checking policy in the application.
+
+If you find application code that bypasses `hc_policy` or sends to a non-voice
+channel, treat it as a P0 regression and stop.
+
+---
+
+## 4. Migration Source Sprawl (Know Where the Truth Lives)
+
+This repo currently has SQL migrations in **four** locations. Before writing a
+new migration or assuming a table doesn't exist, know which tree you're in:
+
+| Path | Role |
+|------|------|
+| `supabase/migrations/` | Primary tree. Source of truth for the production Supabase project (`hvjyfyzotqobfkakjozp`). New schema work goes here. |
+| `supabase/_archived_broken_migrations/` | Quarantine for migrations that failed replay. **Do not edit; do not re-introduce.** |
+| `db/migrations/` | Older payments / global-rails migrations. Treat as historical unless explicitly extending those modules. |
+| `lib/db/migrations/` | One-off route-intelligence unified bundle. Historical. |
+| `haul-command-hub/supabase/migrations/` | A nested sub-app (`haul-command-hub/`) with its own migration history. Not the main app — only edit if the task is explicitly inside that sub-app. |
+
+Rules of thumb:
+
+1. **Do not duplicate tables across trees.** Check `CLAUDE.md` > "Supabase Table
+   Inventory" first; the canonical names there are the only ones agents should
+   target.
+2. New migrations belong in `supabase/migrations/` with the timestamp prefix
+   convention used by the most recent files in that directory.
+3. Never apply DDL via raw `execute_sql`. Use `apply_migration` (per
+   `CLAUDE.md` > "Stack-Specific Verification").
+4. If you suspect two trees disagree, surface the conflict to the user before
+   editing — do not pick a winner silently.
+
+---
+
+## 5. Vercel Scope / Auth Troubleshooting
+
+Symptoms commonly mistaken for "broken code" that are actually scope/auth issues:
+
+- **`vercel` CLI shows the wrong project or "no project linked"** — the local
+  `.vercel/` directory is missing or points elsewhere. Re-link with
+  `vercel link --scope team_2Gdjo2UJF7p1MS0pxYz3HAXh --project prj_CZHigC9LvMTK0mCq7HLuRKxc7VQ3`.
+  Project and team IDs are pinned in `CLAUDE.md` § 10.
+- **"Not authorized" / 403 from Vercel CLI** — token belongs to the wrong scope.
+  Verify with `vercel whoami` and `vercel teams ls`. Switch with
+  `vercel switch <team>`. Never paste a personal token into team CI.
+- **Build green locally, red on Vercel** — TypeScript errors don't fail the
+  Vercel build (`ignoreBuildErrors: true` in `next.config.ts`) but the GitHub
+  Action `.github/workflows/typecheck.yml` does. Run `npx tsc --noEmit`
+  locally; do not bypass the gate.
+- **Static-generation timeouts on `/directory`, `/(app)`, `/admin`** — a route
+  is missing `export const dynamic = 'force-dynamic'`. The Build Guard
+  workflow (`.github/workflows/build-guard.yml`) enumerates the protected
+  prefixes. Add `force-dynamic` and `revalidate = 0`; do not add
+  `generateStaticParams` to those trees.
+- **Domain/DNS issues for `haulcommand.com`** — see `docs/vercel-domain-setup.md`.
+
+Agents must **not** trigger production deploys, change Vercel project settings,
+or rotate tokens without explicit user confirmation.
+
+---
+
+## 6. Repo Hygiene
+
+The repo currently carries large stale artifacts at the root
+(`HomeClient_YP.tsx.tmp`, multiple `tmp-build*.log` / `temp_build.txt` files,
+PowerShell `fix-*.ps1` one-shots, the `update_57.js` rewriter). These are out
+of scope for routine tasks — do not delete them as part of an unrelated change,
+but do not extend them either. If a task is explicitly "clean up stale repo
+artifacts," propose the deletion list to the user first; some of these files
+are referenced by ad-hoc scripts that don't show up in import graphs.
+
+---
+
+## 7. Verification Checklist Before Reporting "Done"
+
+For any non-trivial change, run what's available locally:
+
+- `npm run lint:country-drift` — scope drift
+- `npm run lint:mojibake` — encoding regressions
+- `npm run typecheck` — TypeScript gate
+- `npm run lint` — ESLint
+- `npm run build` — Next build (only when the change can plausibly affect build)
+
+If a check cannot be run in the current environment, say so explicitly in the
+final report and tell the user which command to run themselves. Do not claim a
+verification that did not happen.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "start": "next start",
     "lint": "next lint",
     "lint:mojibake": "node scripts/check-mojibake.js",
+    "lint:country-drift": "node scripts/check-country-drift.js",
     "typecheck": "tsc --noEmit",
     "brand:generate": "node scripts/brand/generate-assets.mjs",
     "brand:verify": "node scripts/brand/verify-assets.mjs",

--- a/scripts/check-country-drift.js
+++ b/scripts/check-country-drift.js
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+/**
+ * scripts/check-country-drift.js
+ *
+ * Pre-commit / CI guard that prevents "57 countries" scope drift from
+ * re-entering live application surfaces.
+ *
+ * Haul Command operates across 120 countries. Any "57 countries" reference
+ * in shipped code (UI, server libs, components, public content) is stale
+ * legacy drift and must not return. Historical artifacts in migrations,
+ * planning docs, and archived scripts are intentionally NOT scanned —
+ * the goal is to prevent regressions in live surfaces, not rewrite history.
+ *
+ * Usage:
+ *   node scripts/check-country-drift.js
+ *
+ * Exit codes:
+ *   0 — clean (no drift in scanned paths)
+ *   1 — drift detected (lists offending file:line)
+ */
+
+const { execSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+
+// Paths that ship to users / Google. These MUST stay on the 120-country scope.
+const SCAN_PATHS = ['app', 'components', 'lib', 'pages'];
+
+// File extensions worth scanning for drift in user-visible / runtime code.
+const EXTS = ['tsx', 'ts', 'jsx', 'js', 'mdx'];
+
+// Known stale phrases. Keep the list small and high-signal — vague matches
+// like the bare number "57" generate too much noise to act on.
+const DRIFT_PATTERNS = [
+  /57\s*countries/gi,
+  /57[\s-]country/gi,
+  /across\s+57\b/gi,
+];
+
+// Allowlist: paths under SCAN_PATHS that intentionally contain the legacy
+// reference (e.g. a SQL migration co-located in lib/db). Add sparingly —
+// the default answer to drift is "fix it," not "allowlist it."
+const ALLOWLIST = [
+  // Historical SQL migration kept verbatim for replay parity.
+  'lib/db/migrations/00_global_route_intelligence_unified.sql',
+];
+
+const repoRoot = process.cwd();
+const findings = [];
+
+function scanFile(rel) {
+  if (ALLOWLIST.includes(rel)) return;
+  let content;
+  try {
+    content = fs.readFileSync(path.join(repoRoot, rel), 'utf8');
+  } catch {
+    return;
+  }
+  const lines = content.split(/\r?\n/);
+  lines.forEach((line, idx) => {
+    for (const pattern of DRIFT_PATTERNS) {
+      pattern.lastIndex = 0;
+      if (pattern.test(line)) {
+        findings.push({
+          file: rel,
+          line: idx + 1,
+          excerpt: line.trim().slice(0, 160),
+        });
+        return;
+      }
+    }
+  });
+}
+
+function listFiles(dir) {
+  // git ls-files keeps the scan honest: only tracked files, no node_modules,
+  // no build output, fast even on large trees.
+  try {
+    const out = execSync(`git ls-files -- "${dir}"`, {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      maxBuffer: 32 * 1024 * 1024,
+    });
+    return out
+      .split('\n')
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .filter((f) => EXTS.includes(path.extname(f).slice(1).toLowerCase()));
+  } catch {
+    return [];
+  }
+}
+
+for (const dir of SCAN_PATHS) {
+  if (!fs.existsSync(path.join(repoRoot, dir))) continue;
+  for (const file of listFiles(dir)) {
+    scanFile(file);
+  }
+}
+
+if (findings.length === 0) {
+  console.log('OK — no 57-country drift in live source paths (' + SCAN_PATHS.join(', ') + ').');
+  process.exit(0);
+}
+
+console.error('');
+console.error('FAIL — 57-country drift detected in live source paths.');
+console.error('Haul Command is a 120-country platform. Update the references below to');
+console.error('"120 countries" (or remove the country count if the surface should be');
+console.error('country-agnostic). See CLAUDE.md section "120-Country Standard".');
+console.error('');
+for (const f of findings) {
+  console.error(`  ${f.file}:${f.line}  ${f.excerpt}`);
+}
+console.error('');
+console.error(`Total drift hits: ${findings.length}`);
+console.error('');
+console.error('If a hit is intentional historical content, add the path to ALLOWLIST');
+console.error('in scripts/check-country-drift.js with a one-line justification.');
+process.exit(1);


### PR DESCRIPTION
## Summary

Adds a CI guardrail that prevents stale "57 countries" scope drift from re-entering live source paths, plus an orientation document for coding agents covering the highest-risk areas of this repo.

### What's in the PR

- **`scripts/check-country-drift.js`** — scans `app/`, `components/`, `lib/`, `pages/` for `57 countries` / `57-country` / `across 57` patterns. Skips historical SQL migrations and planning docs by design (the goal is to prevent regressions in live surfaces, not rewrite history). Has a small explicit allowlist for one historical SQL file.
- **`.github/workflows/country-drift.yml`** — runs the scanner on every push to `main` and every PR.
- **`package.json`** — adds `npm run lint:country-drift`.
- **Three live drift fixes** the scanner found (label/comment changes only):
  - `app/admin/batch-jobs/page.tsx` — `57-Country Regulation Summaries` → `120-Country …` (the description right next to it already said "all 120 countries")
  - `app/admin/dashboards/data-products/page.tsx` — `57-Country Pricing by Tier` → `120-Country …`
  - `app/api/treasury/nowpayments-withdraw/route.ts` — comment `57-Country Check` → `120-Country Check`
- **`docs/agent-guardrails.md`** — orientation doc that points back to `CLAUDE.md` as source of truth and covers:
  - 120-country scope rule + where the scanner lives
  - No-fake-stats rule and the single source of truth (`lib/server/global-stats.ts`)
  - Outreach policy (LiveKit-voice-only, 90-day seasoning, ≥40 authority score) and where it's enforced (`hc_policy` + `trg_claim_outreach_seasoning`)
  - Migration source sprawl — four trees mapped, which is canonical
  - Vercel scope/auth troubleshooting checklist
  - Verification checklist before reporting "done"

### What this PR deliberately does NOT do

- No Supabase migrations applied
- No production deploys triggered
- No outreach config touched
- No secrets touched
- No mass refactor of historical migrations / planning docs containing "57 countries" — that's archival drift; rewriting it would be churn.

## Testing

- [x] `node scripts/check-country-drift.js` → OK after fixes
- [x] `npm run lint:country-drift` → OK
- [x] JSON parse on `package.json`, YAML parse on the new workflow → OK
- [ ] `npx tsc --noEmit` — not run locally; `node_modules` not installed in this environment. The three TS edits are string-literal/comment-only changes and cannot affect type-check. The existing `typecheck.yml` GitHub Action will confirm on this PR.
- [ ] `npm run build` — same reason. Not affected by the edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)