### PR TITLE
Harden sponsor and review safety paths

### DIFF
--- a/app/(onboarding)/claim/ClaimClient.tsx
+++ b/app/(onboarding)/claim/ClaimClient.tsx
@@ -92,7 +92,7 @@ function ClaimPageInner() {
                     lineHeight: 1.5,
                     margin: 0,
                 }}>
-                    Verify your phone to unlock your operator dashboard, respond to loads, and build your trust score.
+                    Confirm your phone so we can start the claim flow and route your profile into proof review.
                 </p>
             </div>
 
@@ -104,9 +104,9 @@ function ClaimPageInner() {
                 marginBottom: 28,
             }}>
                 {[
-                    { icon: Shield, label: 'Verified', desc: 'Badge' },
-                    { icon: Clock, label: '< 2 min', desc: 'To verify' },
-                    { icon: CheckCircle, label: 'Free', desc: 'to claim' },
+                    { icon: Shield, label: 'Phone', desc: 'Confirmed' },
+                    { icon: Clock, label: '< 2 min', desc: 'to submit' },
+                    { icon: CheckCircle, label: 'Free', desc: 'to start' },
                 ].map(({ icon: Icon, label, desc }) => (
                     <div key={label} style={{
                         textAlign: 'center',
@@ -231,9 +231,9 @@ function ClaimPageInner() {
                     What happens next
                 </div>
                 {[
-                    'Enter your code to verify your number',
-                    'Your operator profile activates instantly',
-                    'Start responding to loads and building trust',
+                    'Enter your code to confirm this number',
+                    'Submit profile and proof details for review',
+                    'Update service areas and broker request preferences',
                 ].map((step, i) => (
                     <div key={i} style={{
                         display: 'flex',

--- a/app/api/directory/reviews/route.ts
+++ b/app/api/directory/reviews/route.ts
@@ -131,12 +131,21 @@ export async function POST(req: NextRequest) {
         return NextResponse.json({ error: "overall_rating required (1–5)" }, { status: 400 });
     }
 
+    const optionalRatings = { professionalism, communication, reliability, equipment, safety_score, route_quality };
+    for (const [field, value] of Object.entries(optionalRatings)) {
+        if (value == null) continue;
+        if (typeof value !== "number" || value < 1 || value > 5) {
+            return NextResponse.json({ error: `${field} must be 1-5 when provided` }, { status: 400 });
+        }
+    }
+
     // Anti self-review
     if (targetId === user.id) {
         return NextResponse.json({ error: "Cannot review yourself" }, { status: 400 });
     }
 
-    // Use service role to insert (bypasses RLS)
+    // Use service role only after auth. New reviews stay hidden until a
+    // moderation/evidence job verifies the reviewer relationship.
     const svc = await makeServiceSupabase();
     const { data: review, error } = await svc
         .from("escort_reviews")
@@ -154,7 +163,7 @@ export async function POST(req: NextRequest) {
             review_type: review_type ?? null,
             cargo_type: cargo_type ?? null,
             is_verified: false,
-            is_hidden: false,
+            is_hidden: true,
         })
         .select("id")
         .single();
@@ -170,5 +179,8 @@ export async function POST(req: NextRequest) {
         return NextResponse.json({ error: "Review submission failed" }, { status: 500 });
     }
 
-    return NextResponse.json({ id: review!.id }, { status: 201 });
+    return NextResponse.json(
+        { id: review!.id, status: "pending_review" },
+        { status: 202 },
+    );
 }

--- a/app/api/sponsor/territory/route.ts
+++ b/app/api/sponsor/territory/route.ts
@@ -7,6 +7,7 @@
 export const dynamic = 'force-dynamic';
 import { NextRequest, NextResponse } from 'next/server';
 import { getSupabaseAdmin } from '@/lib/supabase/admin';
+import Stripe from 'stripe';
 
 
 const TERRITORY_PLANS = {
@@ -72,16 +73,19 @@ export async function POST(req: NextRequest) {
             }, { status: 409 });
         }
 
-        // Create Stripe checkout
-        let checkoutUrl = `/sponsor/success?territory=${territory_type}&value=${territory_value}`;
+        if (!process.env.STRIPE_SECRET_KEY) {
+            return NextResponse.json(
+                { error: 'Sponsor checkout is not configured.' },
+                { status: 503 },
+            );
+        }
 
-        if (process.env.STRIPE_SECRET_KEY) {
-            const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY);
+        const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
 
-            const session = await stripe.checkout.sessions.create({
-                mode: 'subscription',
-                customer_email: email,
-                line_items: [{
+        const session = await stripe.checkout.sessions.create({
+            mode: 'subscription',
+            customer_email: email,
+            line_items: [{
                     price_data: {
                         currency: 'usd',
                         product_data: {
@@ -92,19 +96,23 @@ export async function POST(req: NextRequest) {
                         unit_amount: plan.price_monthly * 100,
                         recurring: { interval: 'month' },
                     },
-                    quantity: 1,
-                }],
-                metadata: {
-                    type: 'territory_sponsorship',
-                    territory_type,
-                    territory_value,
-                    company_name,
-                },
-                success_url: `${process.env.NEXT_PUBLIC_SITE_URL || 'https://haulcommand.com'}/sponsor/success?session_id={CHECKOUT_SESSION_ID}`,
-                cancel_url: `${process.env.NEXT_PUBLIC_SITE_URL || 'https://haulcommand.com'}/sponsor/checkout`,
-            });
+                quantity: 1,
+            }],
+            metadata: {
+                type: 'territory_sponsorship',
+                territory_type,
+                territory_value,
+                company_name,
+            },
+            success_url: `${process.env.NEXT_PUBLIC_SITE_URL || 'https://haulcommand.com'}/sponsor/success?session_id={CHECKOUT_SESSION_ID}`,
+            cancel_url: `${process.env.NEXT_PUBLIC_SITE_URL || 'https://haulcommand.com'}/sponsor/checkout`,
+        });
 
-            checkoutUrl = session.url;
+        if (!session.url) {
+            return NextResponse.json(
+                { error: 'Stripe did not return a checkout URL.' },
+                { status: 502 },
+            );
         }
 
         // Record the pending sponsorship (schema: sponsor_user_id, territory_type, territory_value, plan, price_cents_monthly, status)
@@ -135,7 +143,7 @@ export async function POST(req: NextRequest) {
 
         return NextResponse.json({
             ok: true,
-            checkoutUrl,
+            checkoutUrl: session.url,
             plan: {
                 name: plan.name,
                 price: `$${plan.price_monthly}/mo`,

--- a/app/onboarding/claim/ClaimClient.tsx
+++ b/app/onboarding/claim/ClaimClient.tsx
@@ -19,9 +19,9 @@ const PREMIUM_FEATURES = [
 ];
 
 const VERIFICATION_METHODS = [
-    { id: "phone", label: "Phone OTP", icon: Phone, desc: "We'll text a code to your business number", time: "~30 seconds" },
-    { id: "website", label: "Website Token", icon: Globe, desc: "Add a meta tag to your company website", time: "~2 minutes" },
-    { id: "email", label: "Domain Email", icon: Mail, desc: "Verify via your company email address", time: "~1 minute" },
+    { id: "phone", label: "Phone Contact", icon: Phone, desc: "Submit a business number for ownership review", time: "review step" },
+    { id: "website", label: "Website Proof", icon: Globe, desc: "Submit website proof instructions for review", time: "review step" },
+    { id: "email", label: "Domain Email", icon: Mail, desc: "Submit a company email for ownership review", time: "review step" },
 ];
 
 export default function ClaimClient() {
@@ -33,15 +33,13 @@ export default function ClaimClient() {
     const [step, setStep] = useState<"verify" | "plan" | "checkout">("verify");
     const [selectedMethod, setSelectedMethod] = useState<string | null>(null);
     const [verifying, setVerifying] = useState(false);
-    const [verified, setVerified] = useState(false);
     const [selectedPlan, setSelectedPlan] = useState<"free" | "premium">("premium");
 
     async function handleVerify() {
         if (!selectedMethod) return;
         setVerifying(true);
-        // Local ownership step only; proof review happens after submission.
+        // Local ownership method selection only; proof review happens after submission.
         await new Promise(resolve => setTimeout(resolve, 2000));
-        setVerified(true);
         setVerifying(false);
         setStep("plan");
     }


### PR DESCRIPTION
## Summary
- Require a real Stripe Checkout session for territory sponsorships instead of returning a local success URL when Stripe is not configured.
- Keep newly submitted directory reviews hidden and unverified until moderation/evidence review, with optional score validation.
- Remove claim-flow copy that implied instant verification, instant activation, or immediate trust/load access.

## Validation
- `npm run typecheck`
- `npm run build`