### PR TITLE
Wire supply alerts into pricing surfaces

### DIFF
--- a/app/(public)/brokers/page.tsx
+++ b/app/(public)/brokers/page.tsx
@@ -14,6 +14,15 @@ interface ProofData {
   corridors: number;
   surgeActive: number;
   topCorridors: Array<{ label: string; demand: string; loads: number; rate: number }>;
+  supplyAlerts: Array<{
+    id: string;
+    city: string | null;
+    state_code: string | null;
+    corridor_id: string | null;
+    alert_type: string | null;
+    available_count: number | null;
+    message: string | null;
+  }>;
 }
 
 function useProofData(): ProofData {
@@ -22,6 +31,7 @@ function useProofData(): ProofData {
     corridors: 0,
     surgeActive: 0,
     topCorridors: [],
+    supplyAlerts: [],
   });
 
   useEffect(() => {
@@ -47,6 +57,15 @@ function useProofData(): ProofData {
               rate: c.avg_rate_usd,
             })),
           }));
+        }
+      })
+      .catch(() => {});
+
+    fetch('/api/v1/demand-intelligence/supply-alerts?limit=3')
+      .then(r => r.ok ? r.json() : null)
+      .then(d => {
+        if (d?.ok && Array.isArray(d.alerts)) {
+          setData(prev => ({ ...prev, supplyAlerts: d.alerts }));
         }
       })
       .catch(() => {});
@@ -127,7 +146,7 @@ export default function BrokersPage() {
           maxWidth: 520,
         }}>
           Haul Command tracks escort supply and demand pressure across every major corridor in real time.
-          Route smarter. Fill faster. Reduce dead-head risk.
+          Route smarter. Fill faster. Reduce deadhead risk.
         </p>
 
         {/* Proof bar */}
@@ -152,6 +171,12 @@ export default function BrokersPage() {
               <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
                 <div style={{ width: 6, height: 6, borderRadius: '50%', background: '#f97316' }} />
                 <strong style={{ color: '#f97316' }}>{proof.surgeActive}</strong> surge active
+              </div>
+            )}
+            {proof.supplyAlerts.length > 0 && (
+              <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                <div style={{ width: 6, height: 6, borderRadius: '50%', background: '#fb923c' }} />
+                <strong style={{ color: '#fb923c' }}>{proof.supplyAlerts.length}</strong> active supply alert{proof.supplyAlerts.length === 1 ? '' : 's'}
               </div>
             )}
           </div>
@@ -219,6 +244,48 @@ export default function BrokersPage() {
           </div>
         ))}
       </div>
+
+      {proof.supplyAlerts.length > 0 && (
+        <div style={{ padding: '0 20px 36px', maxWidth: 700, margin: '0 auto' }}>
+          <div style={{
+            fontSize: 10,
+            fontWeight: 800,
+            textTransform: 'uppercase',
+            letterSpacing: '0.08em',
+            color: '#8f97a7',
+            marginBottom: 12,
+          }}>
+            Active supply alerts
+          </div>
+          <div style={{ display: 'grid', gap: 10 }}>
+            {proof.supplyAlerts.map(alert => {
+              const label = [alert.city, alert.state_code].filter(Boolean).join(', ') || alert.corridor_id || 'Market alert';
+              return (
+                <div key={alert.id} style={{
+                  padding: 16,
+                  borderRadius: 16,
+                  background: 'rgba(249, 115, 22, 0.08)',
+                  border: '1px solid rgba(249, 115, 22, 0.20)',
+                }}>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12, alignItems: 'flex-start' }}>
+                    <div>
+                      <div style={{ fontSize: 14, fontWeight: 900, color: '#fff7ed' }}>{label}</div>
+                      <div style={{ marginTop: 6, fontSize: 13, lineHeight: 1.55, color: '#fed7aa' }}>
+                        {alert.message || 'Active supply pressure signal. Confirm operator fit before dispatch.'}
+                      </div>
+                    </div>
+                    {typeof alert.available_count === 'number' && (
+                      <div style={{ minWidth: 72, textAlign: 'right', fontSize: 11, color: '#fdba74', fontWeight: 900 }}>
+                        {alert.available_count} signal{alert.available_count === 1 ? '' : 's'}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
 
       {/* Live corridor pressure preview */}
       {proof.topCorridors.length > 0 && (

--- a/app/(public)/sponsor/page.tsx
+++ b/app/(public)/sponsor/page.tsx
@@ -108,6 +108,15 @@ export default function SponsorPage() {
         scarcity_label: string;
         pricing_posture: string;
         surge_active: boolean;
+        surge_multiplier: number;
+        supply_alert_count: number;
+        supply_alerts: Array<{
+            id: string;
+            label: string;
+            message: string;
+            alert_type: string | null;
+            available_count: number | null;
+        }>;
         operator_count: number;
     } | null>(null);
 
@@ -494,6 +503,36 @@ export default function SponsorPage() {
                                     <div style={{ fontSize: 13, color: 'var(--m-text-secondary)', lineHeight: 1.4 }}>
                                         {marketPricing.messaging}
                                     </div>
+                                    {(marketPricing.surge_active || marketPricing.supply_alert_count > 0) && (
+                                        <div style={{
+                                            display: 'grid',
+                                            gap: 8,
+                                            marginTop: 8,
+                                            padding: 10,
+                                            borderRadius: 12,
+                                            border: '1px solid rgba(249, 115, 22, 0.22)',
+                                            background: 'rgba(249, 115, 22, 0.08)',
+                                        }}>
+                                            <div style={{ fontSize: 11, fontWeight: 900, letterSpacing: '0.08em', textTransform: 'uppercase', color: '#fb923c' }}>
+                                                Market pressure
+                                                {marketPricing.surge_active ? ` - ${marketPricing.surge_multiplier.toFixed(1)}x surge signal` : ''}
+                                            </div>
+                                            {marketPricing.supply_alerts.length > 0 ? (
+                                                marketPricing.supply_alerts.map((alert) => (
+                                                    <div key={alert.id} style={{ fontSize: 12, lineHeight: 1.45, color: '#fed7aa' }}>
+                                                        <strong style={{ color: '#fff7ed' }}>{alert.label}:</strong> {alert.message}
+                                                        {typeof alert.available_count === 'number' && (
+                                                            <span style={{ color: '#fdba74' }}> {alert.available_count} availability signal{alert.available_count === 1 ? '' : 's'}.</span>
+                                                        )}
+                                                    </div>
+                                                ))
+                                            ) : (
+                                                <div style={{ fontSize: 12, lineHeight: 1.45, color: '#fed7aa' }}>
+                                                    Demand pressure is elevated. Pricing reflects the live corridor signal; availability still needs operator confirmation.
+                                                </div>
+                                            )}
+                                        </div>
+                                    )}
                                     <div style={{ fontSize: 24, fontWeight: 900, color: 'var(--hc-gold-400)', marginTop: 4 }}>
                                         ${marketPricing.base_price_monthly}<span style={{ fontSize: 13, fontWeight: 600, color: 'var(--m-text-muted)' }}>/mo</span>
                                     </div>

--- a/app/api/sponsor/pricing/route.ts
+++ b/app/api/sponsor/pricing/route.ts
@@ -27,6 +27,15 @@ interface PricingResult {
     operator_count: number;
     demand_pressure: number;
     surge_active: boolean;
+    surge_multiplier: number;
+    supply_alert_count: number;
+    supply_alerts: Array<{
+        id: string;
+        label: string;
+        message: string;
+        alert_type: string | null;
+        available_count: number | null;
+    }>;
     inventory_class: string;
 }
 
@@ -104,7 +113,9 @@ export async function GET(req: NextRequest) {
     let operatorCount = 0;
     let demandPressure = 0;
     let surgeActive = false;
+    let surgeMultiplier = 1.0;
     let inventoryClass = type;
+    let supplyAlerts: PricingResult['supply_alerts'] = [];
 
     // Get density from H3 if provided
     if (h3Cell) {
@@ -128,6 +139,7 @@ export async function GET(req: NextRequest) {
         if (demand) {
             demandPressure = demand.demand_pressure ?? 0;
             surgeActive = demand.surge_active ?? false;
+            surgeMultiplier = Math.max(surgeMultiplier, demand.surge_multiplier ?? 1.0);
         }
 
         // Check supply
@@ -144,6 +156,37 @@ export async function GET(req: NextRequest) {
             demandPressure = Math.max(demandPressure, supply.demand_pressure ?? 0);
         }
     }
+
+    const { data: alerts } = await supabase
+        .from('supply_alerts')
+        .select('id,city,state_code,corridor_id,alert_type,available_count,message,expires_at')
+        .eq('active', true)
+        .order('created_at', { ascending: false })
+        .limit(12);
+
+    const normalizedValue = (value || h3Cell).toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
+    supplyAlerts = (alerts ?? [])
+        .filter((alert: any) => {
+            const expiresAt = alert.expires_at ? new Date(alert.expires_at).getTime() : null;
+            if (expiresAt && expiresAt <= Date.now()) return false;
+            if (!normalizedValue) return true;
+            const city = typeof alert.city === 'string' ? alert.city.toLowerCase() : '';
+            const alertHaystack = [
+                alert.city,
+                alert.state_code,
+                alert.corridor_id,
+                alert.message,
+            ].filter(Boolean).join(' ').toLowerCase().replace(/[^a-z0-9]+/g, ' ');
+            return alertHaystack.includes(normalizedValue) || (city ? normalizedValue.includes(city) : false);
+        })
+        .slice(0, 3)
+        .map((alert: any) => ({
+            id: alert.id,
+            label: [alert.city, alert.state_code].filter(Boolean).join(', ') || alert.corridor_id || 'Market alert',
+            message: alert.message ?? 'Active supply pressure signal for this market.',
+            alert_type: alert.alert_type,
+            available_count: alert.available_count,
+        }));
 
     // Check existing sponsorship
     const { data: existing } = await supabase
@@ -172,6 +215,9 @@ export async function GET(req: NextRequest) {
         operator_count: operatorCount,
         demand_pressure: demandPressure,
         surge_active: surgeActive,
+        surge_multiplier: surgeMultiplier,
+        supply_alert_count: supplyAlerts.length,
+        supply_alerts: supplyAlerts,
         inventory_class: inventoryClass,
     };
 

--- a/app/api/v1/demand-intelligence/supply-alerts/route.ts
+++ b/app/api/v1/demand-intelligence/supply-alerts/route.ts
@@ -1,0 +1,80 @@
+import { NextResponse } from "next/server";
+import { getSupabaseAdmin } from "@/lib/supabase/admin";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+type SupplyAlertRow = {
+  id: string;
+  city: string | null;
+  state_code: string | null;
+  corridor_id: string | null;
+  alert_type: string | null;
+  available_count: number | null;
+  demand_rate: number | null;
+  message: string | null;
+  expires_at: string | null;
+  created_at: string | null;
+};
+
+function isUnexpired(alert: SupplyAlertRow): boolean {
+  if (!alert.expires_at) return true;
+  return new Date(alert.expires_at).getTime() > Date.now();
+}
+
+export async function GET(req: Request) {
+  const supabase = getSupabaseAdmin();
+  const url = new URL(req.url);
+  const limit = Math.min(Math.max(Number(url.searchParams.get("limit") ?? 5), 1), 25);
+  const stateCode = url.searchParams.get("state_code")?.toUpperCase() ?? null;
+  const corridorId = url.searchParams.get("corridor_id") ?? null;
+
+  let query = supabase
+    .from("supply_alerts")
+    .select("id,city,state_code,corridor_id,alert_type,available_count,demand_rate,message,expires_at,created_at")
+    .eq("active", true)
+    .order("created_at", { ascending: false })
+    .limit(limit * 2);
+
+  if (stateCode) query = query.eq("state_code", stateCode);
+  if (corridorId) query = query.eq("corridor_id", corridorId);
+
+  const { data, error } = await query;
+
+  if (error) {
+    return NextResponse.json(
+      {
+        ok: false,
+        alerts_count: 0,
+        alerts: [],
+        source_status: "unavailable",
+      },
+      { headers: { "Cache-Control": "public, max-age=60, stale-while-revalidate=120" } },
+    );
+  }
+
+  const alerts = ((data ?? []) as SupplyAlertRow[])
+    .filter(isUnexpired)
+    .slice(0, limit)
+    .map((alert) => ({
+      id: alert.id,
+      city: alert.city,
+      state_code: alert.state_code,
+      corridor_id: alert.corridor_id,
+      alert_type: alert.alert_type,
+      available_count: alert.available_count,
+      demand_rate: alert.demand_rate,
+      message: alert.message,
+      expires_at: alert.expires_at,
+    }));
+
+  return NextResponse.json(
+    {
+      ok: true,
+      alerts_count: alerts.length,
+      alerts,
+      source_status: "live",
+    },
+    { headers: { "Cache-Control": "public, max-age=120, stale-while-revalidate=300" } },
+  );
+}


### PR DESCRIPTION
## Summary
- Add a safe public supply-alert API for active, unexpired market pressure signals.
- Extend sponsor pricing with surge multiplier and active supply-alert context.
- Surface active supply alerts on the broker page so scarcity/pressure copy is backed by database signals.

## Validation
- `npm run typecheck`
- `npm run build`

## Notes
The supply-alert endpoint returns an empty unavailable state instead of failing public pages if the optional table/query is unavailable.