### PR TITLE
Build pilot car rate calculator engine

### DIFF
--- a/app/(public)/tools/pilot-car-rate-calculator/PilotCarRateCalculatorClient.tsx
+++ b/app/(public)/tools/pilot-car-rate-calculator/PilotCarRateCalculatorClient.tsx
@@ -1,0 +1,216 @@
+'use client';
+
+import Link from 'next/link';
+import { useMemo, useState } from 'react';
+import {
+  calculatePilotCarRate,
+  pilotCarDifficultyLabels,
+  pilotCarRegionLabels,
+  type PilotCarDifficulty,
+  type PilotCarRegion,
+} from '@/lib/tools/pilotCarRate';
+
+const regions = Object.entries(pilotCarRegionLabels) as [PilotCarRegion, string][];
+const difficulties = Object.entries(pilotCarDifficultyLabels) as [PilotCarDifficulty, string][];
+
+function formatCurrency(value: number) {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+export function PilotCarRateCalculatorClient() {
+  const [miles, setMiles] = useState(650);
+  const [escortCount, setEscortCount] = useState(2);
+  const [waitHours, setWaitHours] = useState(4);
+  const [overnightNights, setOvernightNights] = useState(1);
+  const [region, setRegion] = useState<PilotCarRegion>('texas_gulf');
+  const [difficulty, setDifficulty] = useState<PilotCarDifficulty>('overwide');
+  const [highPole, setHighPole] = useState(false);
+
+  const result = useMemo(
+    () =>
+      calculatePilotCarRate({
+        miles,
+        escortCount,
+        waitHours,
+        overnightNights,
+        region,
+        difficulty,
+        highPole,
+      }),
+    [difficulty, escortCount, highPole, miles, overnightNights, region, waitHours],
+  );
+
+  const rows = [
+    ['Escort labor', result.escortLabor],
+    ['Mileage charge', result.mileageCharge],
+    ['Wait / detention', result.waitCharge],
+    ['High-pole add-on', result.highPoleCharge],
+    ['Overnight / per diem', result.overnightCharge],
+    ['Fuel surcharge estimate', result.fuelSurcharge],
+  ];
+
+  return (
+    <div className="min-h-screen bg-[#0B0F14] text-white">
+      <section className="border-b border-[#F1A91B]/10 bg-[#0B0F14]">
+        <div className="mx-auto max-w-5xl px-4 py-12">
+          <div className="mb-4 flex items-center gap-2 text-xs font-bold uppercase tracking-[0.2em] text-[#F1A91B]">
+            <Link href="/tools" className="hover:text-white">Tools</Link>
+            <span>/</span>
+            <span>Rates</span>
+          </div>
+          <h1 className="max-w-3xl text-3xl font-black tracking-tight md:text-5xl">
+            Pilot Car Rate Calculator
+          </h1>
+          <p className="mt-4 max-w-3xl text-base leading-7 text-slate-300">
+            Estimate pilot car and escort pricing from route miles, escort count, wait time,
+            high-pole needs, and regional rate pressure. This is a planning calculator,
+            not a binding quote; final rates depend on operator availability, permit windows,
+            route restrictions, and authority requirements.
+          </p>
+        </div>
+      </section>
+
+      <main className="mx-auto grid max-w-5xl gap-6 px-4 py-8 lg:grid-cols-[1fr_360px]">
+        <section className="rounded-2xl border border-white/10 bg-[#111827] p-5">
+          <h2 className="text-lg font-black">Move Details</h2>
+          <div className="mt-5 grid gap-4 sm:grid-cols-2">
+            <label className="block">
+              <span className="text-xs font-bold uppercase tracking-wider text-slate-400">Route miles</span>
+              <input
+                type="number"
+                min={1}
+                value={miles}
+                onChange={(event) => setMiles(Number(event.target.value))}
+                className="mt-2 w-full rounded-xl border border-white/10 bg-[#0B0F14] px-3 py-3 text-white outline-none focus:border-[#F1A91B]"
+              />
+            </label>
+            <label className="block">
+              <span className="text-xs font-bold uppercase tracking-wider text-slate-400">Escort vehicles</span>
+              <input
+                type="number"
+                min={1}
+                max={8}
+                value={escortCount}
+                onChange={(event) => setEscortCount(Number(event.target.value))}
+                className="mt-2 w-full rounded-xl border border-white/10 bg-[#0B0F14] px-3 py-3 text-white outline-none focus:border-[#F1A91B]"
+              />
+            </label>
+            <label className="block">
+              <span className="text-xs font-bold uppercase tracking-wider text-slate-400">Region</span>
+              <select
+                value={region}
+                onChange={(event) => setRegion(event.target.value as PilotCarRegion)}
+                className="mt-2 w-full rounded-xl border border-white/10 bg-[#0B0F14] px-3 py-3 text-white outline-none focus:border-[#F1A91B]"
+              >
+                {regions.map(([value, label]) => (
+                  <option key={value} value={value}>{label}</option>
+                ))}
+              </select>
+            </label>
+            <label className="block">
+              <span className="text-xs font-bold uppercase tracking-wider text-slate-400">Load difficulty</span>
+              <select
+                value={difficulty}
+                onChange={(event) => setDifficulty(event.target.value as PilotCarDifficulty)}
+                className="mt-2 w-full rounded-xl border border-white/10 bg-[#0B0F14] px-3 py-3 text-white outline-none focus:border-[#F1A91B]"
+              >
+                {difficulties.map(([value, label]) => (
+                  <option key={value} value={value}>{label}</option>
+                ))}
+              </select>
+            </label>
+            <label className="block">
+              <span className="text-xs font-bold uppercase tracking-wider text-slate-400">Wait / detention hours</span>
+              <input
+                type="number"
+                min={0}
+                value={waitHours}
+                onChange={(event) => setWaitHours(Number(event.target.value))}
+                className="mt-2 w-full rounded-xl border border-white/10 bg-[#0B0F14] px-3 py-3 text-white outline-none focus:border-[#F1A91B]"
+              />
+            </label>
+            <label className="block">
+              <span className="text-xs font-bold uppercase tracking-wider text-slate-400">Overnight nights</span>
+              <input
+                type="number"
+                min={0}
+                value={overnightNights}
+                onChange={(event) => setOvernightNights(Number(event.target.value))}
+                className="mt-2 w-full rounded-xl border border-white/10 bg-[#0B0F14] px-3 py-3 text-white outline-none focus:border-[#F1A91B]"
+              />
+            </label>
+          </div>
+
+          <label className="mt-5 flex items-center gap-3 rounded-xl border border-white/10 bg-[#0B0F14] p-4">
+            <input
+              type="checkbox"
+              checked={highPole}
+              onChange={(event) => setHighPole(event.target.checked)}
+              className="h-5 w-5 accent-[#F1A91B]"
+            />
+            <span>
+              <span className="block text-sm font-bold">Include high-pole / height-pole car</span>
+              <span className="text-xs text-slate-400">Use when overheight risk or permit language requires it.</span>
+            </span>
+          </label>
+
+          <div className="mt-6 rounded-xl border border-[#F1A91B]/20 bg-[#0B0F14] p-4">
+            <h3 className="text-sm font-black text-[#F1A91B]">Estimate Range</h3>
+            <div className="mt-3 grid gap-3 sm:grid-cols-3">
+              <div>
+                <div className="text-xs text-slate-500">Low</div>
+                <div className="text-2xl font-black">{formatCurrency(result.lowEstimate)}</div>
+              </div>
+              <div>
+                <div className="text-xs text-slate-500">Planning Midpoint</div>
+                <div className="text-2xl font-black text-[#F1A91B]">{formatCurrency(result.midEstimate)}</div>
+              </div>
+              <div>
+                <div className="text-xs text-slate-500">High</div>
+                <div className="text-2xl font-black">{formatCurrency(result.highEstimate)}</div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <aside className="space-y-4">
+          <div className="rounded-2xl border border-white/10 bg-[#111827] p-5">
+            <h2 className="text-lg font-black">Rate Breakdown</h2>
+            <div className="mt-4 space-y-3">
+              {rows.map(([label, value]) => (
+                <div key={label} className="flex items-center justify-between border-b border-white/5 pb-2 text-sm">
+                  <span className="text-slate-400">{label}</span>
+                  <span className="font-bold">{formatCurrency(value as number)}</span>
+                </div>
+              ))}
+            </div>
+            <div className="mt-4 rounded-xl bg-[#0B0F14] p-4 text-sm text-slate-300">
+              <div><strong>{result.travelDays}</strong> travel day estimate</div>
+              <div><strong>{result.billableMiles}</strong> billable miles</div>
+              <div><strong>{formatCurrency(result.perEscortMid)}</strong> midpoint per escort</div>
+            </div>
+          </div>
+
+          <div className="rounded-2xl border border-[#F1A91B]/20 bg-[#111827] p-5">
+            <h2 className="text-lg font-black">Next Actions</h2>
+            <div className="mt-4 grid gap-3">
+              <Link href="/directory?category=pilot-car" className="rounded-xl bg-[#F1A91B] px-4 py-3 text-center text-sm font-black text-black">
+                Find pilot car operators
+              </Link>
+              <Link href="/quote" className="rounded-xl border border-white/10 px-4 py-3 text-center text-sm font-bold text-white hover:border-[#F1A91B]">
+                Request a move quote
+              </Link>
+              <Link href="/tools/total-trip-cost-calculator" className="rounded-xl border border-white/10 px-4 py-3 text-center text-sm font-bold text-white hover:border-[#F1A91B]">
+                Add permits and fuel
+              </Link>
+            </div>
+          </div>
+        </aside>
+      </main>
+    </div>
+  );
+}

--- a/app/(public)/tools/pilot-car-rate-calculator/page.tsx
+++ b/app/(public)/tools/pilot-car-rate-calculator/page.tsx
@@ -1,0 +1,55 @@
+import type { Metadata } from 'next';
+import { JsonLd } from '@/components/seo/JsonLd';
+import { PilotCarRateCalculatorClient } from './PilotCarRateCalculatorClient';
+
+export const metadata: Metadata = {
+  title: 'Pilot Car Rate Calculator | Haul Command',
+  description:
+    'Estimate pilot car and escort vehicle rates by miles, escort count, region, high-pole needs, wait time, and load difficulty. Free planning calculator.',
+  alternates: { canonical: 'https://www.haulcommand.com/tools/pilot-car-rate-calculator' },
+};
+
+export default function PilotCarRateCalculatorPage() {
+  const schema = {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'Pilot Car Rate Calculator',
+    url: 'https://www.haulcommand.com/tools/pilot-car-rate-calculator',
+    description:
+      'Estimate pilot car and escort vehicle pricing for oversize load moves using route miles, escort count, market region, and move difficulty.',
+    applicationCategory: 'BusinessApplication',
+    isAccessibleForFree: true,
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  };
+
+  const faq = {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: [
+      {
+        '@type': 'Question',
+        name: 'How much does a pilot car cost?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: 'Pilot car rates commonly include a daily charge, mileage charge, fuel surcharge, wait time, overnight costs, and specialty add-ons such as high-pole service. Final pricing depends on market, permits, load dimensions, route restrictions, and operator availability.',
+        },
+      },
+      {
+        '@type': 'Question',
+        name: 'Why do pilot car rates vary by region?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: 'Rates vary because operator supply, fuel cost, insurance cost, terrain, metro restrictions, and permit complexity differ by market. High-demand corridors and short-notice moves usually price higher.',
+        },
+      },
+    ],
+  };
+
+  return (
+    <>
+      <JsonLd data={schema} />
+      <JsonLd data={faq} />
+      <PilotCarRateCalculatorClient />
+    </>
+  );
+}

--- a/lib/tools/pilotCarRate.ts
+++ b/lib/tools/pilotCarRate.ts
@@ -1,0 +1,138 @@
+export type PilotCarRegion =
+  | 'southeast'
+  | 'texas_gulf'
+  | 'midwest'
+  | 'mountain_west'
+  | 'west_coast'
+  | 'northeast'
+  | 'canada';
+
+export type PilotCarDifficulty =
+  | 'standard'
+  | 'overwide'
+  | 'overheight'
+  | 'superload'
+  | 'emergency';
+
+export type PilotCarRateInput = {
+  miles: number;
+  escortCount: number;
+  waitHours: number;
+  region: PilotCarRegion;
+  difficulty: PilotCarDifficulty;
+  highPole: boolean;
+  overnightNights: number;
+};
+
+export type PilotCarRateResult = {
+  travelDays: number;
+  billableMiles: number;
+  dailyRate: number;
+  mileageRate: number;
+  escortLabor: number;
+  mileageCharge: number;
+  waitCharge: number;
+  highPoleCharge: number;
+  overnightCharge: number;
+  fuelSurcharge: number;
+  lowEstimate: number;
+  midEstimate: number;
+  highEstimate: number;
+  perEscortMid: number;
+};
+
+const REGION_DAILY_RATE: Record<PilotCarRegion, number> = {
+  southeast: 425,
+  texas_gulf: 475,
+  midwest: 450,
+  mountain_west: 525,
+  west_coast: 575,
+  northeast: 625,
+  canada: 650,
+};
+
+const REGION_MILEAGE_RATE: Record<PilotCarRegion, number> = {
+  southeast: 1.15,
+  texas_gulf: 1.25,
+  midwest: 1.2,
+  mountain_west: 1.35,
+  west_coast: 1.45,
+  northeast: 1.5,
+  canada: 1.55,
+};
+
+const DIFFICULTY_FACTOR: Record<PilotCarDifficulty, number> = {
+  standard: 1,
+  overwide: 1.12,
+  overheight: 1.2,
+  superload: 1.42,
+  emergency: 1.65,
+};
+
+function clampNumber(value: number, min: number, max: number) {
+  if (!Number.isFinite(value)) return min;
+  return Math.min(max, Math.max(min, value));
+}
+
+function dollars(value: number) {
+  return Math.round(value);
+}
+
+export function calculatePilotCarRate(input: PilotCarRateInput): PilotCarRateResult {
+  const miles = clampNumber(input.miles, 1, 5000);
+  const escortCount = clampNumber(input.escortCount, 1, 8);
+  const waitHours = clampNumber(input.waitHours, 0, 96);
+  const overnightNights = clampNumber(input.overnightNights, 0, 30);
+  const region = input.region in REGION_DAILY_RATE ? input.region : 'southeast';
+  const difficulty = input.difficulty in DIFFICULTY_FACTOR ? input.difficulty : 'standard';
+
+  const travelDays = Math.max(1, Math.ceil(miles / 350));
+  const billableMiles = Math.max(150, miles);
+  const dailyRate = REGION_DAILY_RATE[region];
+  const mileageRate = REGION_MILEAGE_RATE[region];
+  const factor = DIFFICULTY_FACTOR[difficulty];
+
+  const escortLabor = escortCount * travelDays * dailyRate * factor;
+  const mileageCharge = escortCount * billableMiles * mileageRate;
+  const waitCharge = escortCount * waitHours * 85;
+  const highPoleCharge = input.highPole ? travelDays * 625 : 0;
+  const overnightCharge = escortCount * overnightNights * 135;
+  const subtotal = escortLabor + mileageCharge + waitCharge + highPoleCharge + overnightCharge;
+  const fuelSurcharge = subtotal * 0.14;
+  const midEstimate = subtotal + fuelSurcharge;
+
+  return {
+    travelDays,
+    billableMiles,
+    dailyRate,
+    mileageRate,
+    escortLabor: dollars(escortLabor),
+    mileageCharge: dollars(mileageCharge),
+    waitCharge: dollars(waitCharge),
+    highPoleCharge: dollars(highPoleCharge),
+    overnightCharge: dollars(overnightCharge),
+    fuelSurcharge: dollars(fuelSurcharge),
+    lowEstimate: dollars(midEstimate * 0.84),
+    midEstimate: dollars(midEstimate),
+    highEstimate: dollars(midEstimate * 1.2),
+    perEscortMid: dollars(midEstimate / escortCount),
+  };
+}
+
+export const pilotCarRegionLabels: Record<PilotCarRegion, string> = {
+  southeast: 'Southeast',
+  texas_gulf: 'Texas / Gulf Coast',
+  midwest: 'Midwest',
+  mountain_west: 'Mountain West',
+  west_coast: 'West Coast',
+  northeast: 'Northeast',
+  canada: 'Canada',
+};
+
+export const pilotCarDifficultyLabels: Record<PilotCarDifficulty, string> = {
+  standard: 'Standard oversize',
+  overwide: 'Overwide / two-lane sensitivity',
+  overheight: 'Overheight / high-pole risk',
+  superload: 'Superload / route survey likely',
+  emergency: 'Emergency or short-notice move',
+};

--- a/tests/unit/pilot-car-rate-calculator.test.ts
+++ b/tests/unit/pilot-car-rate-calculator.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { calculatePilotCarRate } from '@/lib/tools/pilotCarRate';
+
+describe('calculatePilotCarRate', () => {
+  it('returns a defensible range and component breakdown for a standard two-escort move', () => {
+    const result = calculatePilotCarRate({
+      miles: 650,
+      escortCount: 2,
+      waitHours: 4,
+      region: 'texas_gulf',
+      difficulty: 'overwide',
+      highPole: false,
+      overnightNights: 1,
+    });
+
+    expect(result.travelDays).toBe(2);
+    expect(result.billableMiles).toBe(650);
+    expect(result.midEstimate).toBeGreaterThan(result.lowEstimate);
+    expect(result.highEstimate).toBeGreaterThan(result.midEstimate);
+    expect(result.escortLabor).toBeGreaterThan(0);
+    expect(result.mileageCharge).toBeGreaterThan(0);
+    expect(result.waitCharge).toBe(680);
+  });
+
+  it('adds high-pole charges and clamps unsafe input extremes', () => {
+    const result = calculatePilotCarRate({
+      miles: -100,
+      escortCount: 99,
+      waitHours: 200,
+      region: 'northeast',
+      difficulty: 'superload',
+      highPole: true,
+      overnightNights: 99,
+    });
+
+    expect(result.billableMiles).toBe(150);
+    expect(result.travelDays).toBe(1);
+    expect(result.highPoleCharge).toBe(625);
+    expect(result.waitCharge).toBe(8 * 96 * 85);
+    expect(result.overnightCharge).toBe(8 * 30 * 135);
+  });
+});


### PR DESCRIPTION
## Summary
- adds a real `/tools/pilot-car-rate-calculator` route for the live registry row that currently 404s
- adds a tested pilot car rate calculation module covering mileage, escort count, wait time, high-pole add-on, overnight costs, region, and load difficulty
- adds an interactive client calculator with estimate range, component breakdown, schema, FAQ, and conversion links

## Verification
- `npm test -- tests/unit/pilot-car-rate-calculator.test.ts`
- `npm run typecheck`
- `npm run build`

## Notes
This fixes one live public tools defect found during the post-deploy audit: the registry marks `pilot-car-rate-calculator` as live, but production currently returns 404 for that URL.