### PR TITLE
Build axle weight calculator engine

### DIFF
--- a/app/(public)/tools/axle-weight-calculator/AxleWeightCalculatorClient.tsx
+++ b/app/(public)/tools/axle-weight-calculator/AxleWeightCalculatorClient.tsx
@@ -1,0 +1,304 @@
+'use client';
+
+import Link from 'next/link';
+import { useMemo, useState } from 'react';
+import {
+  STATE_WEIGHT_LIMITS,
+  calculateFederalBridgeLimit,
+  evaluateAxleWeight,
+  getStateWeightLimit,
+} from '@/lib/tools/axleWeight';
+
+const AXLE_PRESETS = [
+  { label: '5-axle tractor trailer', axleCount: 5, bridgeFeet: 51, grossWeight: 80000 },
+  { label: '6-axle lowboy', axleCount: 6, bridgeFeet: 55, grossWeight: 96000 },
+  { label: '7-axle heavy haul', axleCount: 7, bridgeFeet: 60, grossWeight: 110000 },
+  { label: '9-axle superload', axleCount: 9, bridgeFeet: 70, grossWeight: 140000 },
+];
+
+export function AxleWeightCalculatorClient() {
+  const [axleCount, setAxleCount] = useState(5);
+  const [outerBridgeFeet, setOuterBridgeFeet] = useState(51);
+  const [grossWeightLbs, setGrossWeightLbs] = useState(80000);
+  const [stateCode, setStateCode] = useState('US');
+
+  const state = getStateWeightLimit(stateCode);
+  const result = useMemo(
+    () =>
+      evaluateAxleWeight({
+        axleCount,
+        outerBridgeFeet,
+        grossWeightLbs,
+        singleAxleMaxLbs: state.singleAxleLbs,
+        tandemAxleMaxLbs: state.tandemAxleLbs,
+        stateCode,
+      }),
+    [axleCount, grossWeightLbs, outerBridgeFeet, state, stateCode],
+  );
+
+  const statusColor = result.status === 'legal' ? '#86efac' : '#fca5a5';
+
+  function applyPreset(preset: (typeof AXLE_PRESETS)[number]) {
+    setAxleCount(preset.axleCount);
+    setOuterBridgeFeet(preset.bridgeFeet);
+    setGrossWeightLbs(preset.grossWeight);
+  }
+
+  return (
+    <main className="min-h-screen bg-[#07090d] text-[#f0f2f5]" data-hc-topic-hero="manual">
+      <section className="border-b border-[#131c28] bg-gradient-to-r from-[#0a1929] to-[#07090d] px-5 py-10 md:px-8 lg:px-12">
+        <div className="mx-auto grid max-w-7xl gap-8 lg:grid-cols-[1fr_360px] lg:items-end">
+          <div>
+            <p className="text-[11px] font-black uppercase tracking-[0.24em] text-[#22c55e]">
+              Free Tool / No Login Required
+            </p>
+            <h1 className="mt-4 max-w-4xl text-4xl font-black uppercase tracking-tight md:text-6xl">
+              Axle Weight Calculator
+            </h1>
+            <p className="mt-5 max-w-3xl text-base leading-7 text-[#8a9ab0] md:text-lg">
+              Run a Federal Bridge Formula screen by axle count, outer bridge spacing, gross
+              weight, and planning state before you quote, permit, or dispatch an oversize move.
+            </p>
+          </div>
+          <div className="rounded-2xl border border-[#1e3048] bg-[#0f1a24] p-5">
+            <div className="text-xs font-black uppercase tracking-[0.18em] text-[#566880]">
+              Result
+            </div>
+            <div className="mt-3 text-3xl font-black uppercase" style={{ color: statusColor }}>
+              {result.status === 'legal' ? 'Planning Legal' : 'Over Limit'}
+            </div>
+            <p className="mt-3 text-sm leading-6 text-[#8a9ab0]">{result.summary}</p>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto grid max-w-7xl gap-6 px-5 py-8 md:px-8 lg:grid-cols-[420px_1fr] lg:px-12">
+        <form className="rounded-2xl border border-[#1e3048] bg-[#0f1a24] p-5">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <NumberField
+              label="Axles in group"
+              value={axleCount}
+              min={1}
+              max={12}
+              step={1}
+              onChange={setAxleCount}
+            />
+            <NumberField
+              label="Outer bridge feet"
+              value={outerBridgeFeet}
+              min={4}
+              max={120}
+              step={1}
+              onChange={setOuterBridgeFeet}
+            />
+          </div>
+
+          <div className="mt-4">
+            <NumberField
+              label="Actual gross weight"
+              value={grossWeightLbs}
+              min={10000}
+              max={250000}
+              step={500}
+              onChange={setGrossWeightLbs}
+            />
+          </div>
+
+          <div className="mt-4">
+            <label className="text-xs font-black uppercase tracking-[0.18em] text-[#566880]">
+              Planning jurisdiction
+            </label>
+            <select
+              value={stateCode}
+              onChange={(event) => setStateCode(event.target.value)}
+              className="mt-2 w-full rounded-xl border border-[#1e3048] bg-[#07090d] px-3 py-3 text-sm font-semibold text-white"
+            >
+              {STATE_WEIGHT_LIMITS.map((limit) => (
+                <option key={limit.code} value={limit.code}>
+                  {limit.name} ({limit.code})
+                </option>
+              ))}
+            </select>
+            <p className="mt-2 text-xs leading-5 text-[#566880]">{state.note}</p>
+          </div>
+
+          <div className="mt-6">
+            <div className="text-xs font-black uppercase tracking-[0.18em] text-[#566880]">
+              Common presets
+            </div>
+            <div className="mt-3 grid gap-2">
+              {AXLE_PRESETS.map((preset) => (
+                <button
+                  key={preset.label}
+                  type="button"
+                  onClick={() => applyPreset(preset)}
+                  className="rounded-xl border border-[#1e3048] bg-[#07090d] px-3 py-3 text-left text-sm font-bold text-white transition hover:border-[#22c55e]"
+                >
+                  {preset.label}
+                  <span className="block text-xs font-medium text-[#566880]">
+                    {preset.axleCount} axles / {preset.bridgeFeet} ft / {preset.grossWeight.toLocaleString()} lb
+                  </span>
+                </button>
+              ))}
+            </div>
+          </div>
+        </form>
+
+        <div className="space-y-5">
+          <section className="grid gap-4 md:grid-cols-4">
+            <Metric label="Bridge formula limit" value={`${result.bridgeLimitLbs.toLocaleString()} lb`} />
+            <Metric label="Controlling limit" value={`${result.controllingLimitLbs.toLocaleString()} lb`} />
+            <Metric label={result.overByLbs > 0 ? 'Over by' : 'Under by'} value={`${(result.overByLbs || result.underByLbs).toLocaleString()} lb`} />
+            <Metric label="Permit signal" value={result.permitLikelyRequired ? 'Likely' : 'Check route'} />
+          </section>
+
+          <section className="rounded-2xl border border-[#1e3048] bg-[#0f1a24] p-5">
+            <h2 className="text-2xl font-black uppercase tracking-tight">Bridge Formula</h2>
+            <div className="mt-4 rounded-xl bg-[#07090d] p-4 text-center font-mono text-sm text-[#22c55e]">
+              W = 500 x (LN / (N - 1) + 12N + 36)
+            </div>
+            <div className="mt-4 grid gap-3 text-xs md:grid-cols-3">
+              <FormulaCard label="W" body="Maximum allowed weight in pounds for the axle group." />
+              <FormulaCard label="L" body="Feet between the outer axles in the group being checked." />
+              <FormulaCard label="N" body="Number of axles in the group under consideration." />
+            </div>
+          </section>
+
+          <section className="rounded-2xl border border-[#1e3048] bg-[#0f1a24] p-5">
+            <div className="flex flex-wrap items-end justify-between gap-3">
+              <div>
+                <h2 className="text-2xl font-black uppercase tracking-tight">State Planning Limits</h2>
+                <p className="mt-1 text-sm text-[#8a9ab0]">
+                  Use as a planning screen only. Final legal limits come from the active permit,
+                  route, bridge posting, and state authority.
+                </p>
+              </div>
+              <Link
+                href="/permits/request"
+                className="rounded-xl bg-[#22c55e] px-4 py-3 text-sm font-black text-[#071009]"
+              >
+                Request permit help
+              </Link>
+            </div>
+            <div className="mt-5 overflow-x-auto">
+              <table className="w-full min-w-[720px] border-collapse text-xs">
+                <thead>
+                  <tr className="border-b border-[#1e3048] text-left text-[#566880]">
+                    <th className="py-2 pr-4">State</th>
+                    <th className="py-2 pr-4">GVW</th>
+                    <th className="py-2 pr-4">Single axle</th>
+                    <th className="py-2 pr-4">Tandem</th>
+                    <th className="py-2 pr-4">Note</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {STATE_WEIGHT_LIMITS.map((limit) => (
+                    <tr key={limit.code} className="border-b border-[#131c28] hover:bg-[#111821]">
+                      <td className="py-3 pr-4 font-bold text-[#d0dce8]">{limit.code}</td>
+                      <td className="py-3 pr-4 text-[#8a9ab0]">{limit.gvwLimitLbs.toLocaleString()} lb</td>
+                      <td className="py-3 pr-4 text-[#8a9ab0]">{limit.singleAxleLbs.toLocaleString()} lb</td>
+                      <td className="py-3 pr-4 text-[#8a9ab0]">{limit.tandemAxleLbs.toLocaleString()} lb</td>
+                      <td className="py-3 pr-4 text-[#566880]">{limit.note}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <section className="grid gap-4 md:grid-cols-3">
+            <ActionCard
+              title="Check load dimensions"
+              body="Pair weight screening with width, height, and length thresholds."
+              href="/tools/load-dimension-checker"
+              label="Open dimension checker"
+            />
+            <ActionCard
+              title="Estimate permits"
+              body="Move overweight results into permit-cost and lead-time planning."
+              href="/tools/permit-sla-tracker"
+              label="Check permit SLA"
+            />
+            <ActionCard
+              title="Find escorts"
+              body="Route legal-risk moves toward verified operators and compliance support."
+              href="/directory?category=pilot-car"
+              label="Find operators"
+            />
+          </section>
+        </div>
+      </section>
+    </main>
+  );
+}
+
+function NumberField({
+  label,
+  value,
+  min,
+  max,
+  step,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  onChange: (value: number) => void;
+}) {
+  return (
+    <label className="block">
+      <span className="text-xs font-black uppercase tracking-[0.18em] text-[#566880]">{label}</span>
+      <input
+        type="number"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(event) => onChange(Number(event.target.value))}
+        className="mt-2 w-full rounded-xl border border-[#1e3048] bg-[#07090d] px-3 py-3 text-sm font-semibold text-white"
+      />
+    </label>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-2xl border border-[#1e3048] bg-[#0f1a24] p-4">
+      <div className="text-xs font-black uppercase tracking-[0.18em] text-[#566880]">{label}</div>
+      <div className="mt-2 text-2xl font-black text-[#22c55e]">{value}</div>
+    </div>
+  );
+}
+
+function FormulaCard({ label, body }: { label: string; body: string }) {
+  return (
+    <div className="rounded-xl bg-[#07090d] p-3">
+      <span className="font-black text-[#d4950e]">{label}</span>
+      <p className="mt-1 leading-5 text-[#8a9ab0]">{body}</p>
+    </div>
+  );
+}
+
+function ActionCard({
+  title,
+  body,
+  href,
+  label,
+}: {
+  title: string;
+  body: string;
+  href: string;
+  label: string;
+}) {
+  return (
+    <div className="rounded-2xl border border-[#1e3048] bg-[#0f1a24] p-5">
+      <h3 className="text-lg font-black uppercase tracking-tight">{title}</h3>
+      <p className="mt-2 text-sm leading-6 text-[#8a9ab0]">{body}</p>
+      <Link href={href} className="mt-4 inline-flex text-sm font-black text-[#22c55e] hover:text-white">
+        {label}
+      </Link>
+    </div>
+  );
+}

--- a/app/(public)/tools/axle-weight-calculator/page.tsx
+++ b/app/(public)/tools/axle-weight-calculator/page.tsx
@@ -1,143 +1,55 @@
-import { Metadata } from 'next'
-import { JsonLd } from '@/components/seo/JsonLd'
-import Link from 'next/link'
+import type { Metadata } from 'next';
+import { JsonLd } from '@/components/seo/JsonLd';
+import { AxleWeightCalculatorClient } from './AxleWeightCalculatorClient';
 
 export const metadata: Metadata = {
-  title: 'Axle Weight Calculator — Federal Bridge Formula by State | Haul Command',
-  description: 'Calculate legal axle weights using the federal bridge formula. Check compliance for all US states. Free, no login required.',
+  title: 'Axle Weight Calculator | Federal Bridge Formula | Haul Command',
+  description:
+    'Calculate Federal Bridge Formula axle-weight limits by axle count, bridge spacing, gross weight, and planning state. Free oversize-load weight screen.',
   alternates: { canonical: 'https://www.haulcommand.com/tools/axle-weight-calculator' },
-}
-
-// Federal bridge formula: W = 500 * (LN/(N-1) + 12N + 36)
-// W = max weight in lbs, L = distance between outer axles (ft), N = number of axles
-const AXLE_CONFIGS = [
-  { label:'Single Axle',          axles:1, legal_lbs:20000 },
-  { label:'Tandem Axle',          axles:2, legal_lbs:34000 },
-  { label:'Tridem Axle',          axles:3, legal_lbs:42000 },
-  { label:'Quad Axle',            axles:4, legal_lbs:50000 },
-  { label:'5-Axle Semi',          axles:5, legal_lbs:80000 },
-  { label:'6-Axle',               axles:6, legal_lbs:80000 },
-  { label:'7-Axle Lowboy',        axles:7, legal_lbs:105500 },
-  { label:'9-Axle Multi',         axles:9, legal_lbs:129000 },
-]
-
-const STATE_GVW: Record<string, { gvw: number; single: number; tandem: number; note: string }> = {
-  TX: { gvw:80000, single:25000, tandem:46000, note:'TX allows 25k single axle on state highways with permit' },
-  CA: { gvw:80000, single:20000, tandem:34000, note:'Strict enforcement. No tolerance for bridge formula.' },
-  FL: { gvw:80000, single:22000, tandem:44000, note:'FL allows 22k single and 44k tandem on state roads' },
-  OH: { gvw:80000, single:20000, tandem:34000, note:'OH has strict seasonal weight limits (spring thaw)' },
-  WA: { gvw:105500, single:20000, tandem:34000, note:'WA allows up to 105,500 lbs GVW on some routes' },
-  MI: { gvw:164000, single:18000, tandem:32000, note:'MI has highest GVW limits in US on qualified routes' },
-  NY: { gvw:80000, single:22400, tandem:36000, note:'NY has NYSDOT bridge formula separate from federal' },
-  PA: { gvw:80000, single:20000, tandem:34000, note:'PA has 6% enforcement tolerance on certified scales' },
-  AZ: { gvw:80000, single:20000, tandem:34000, note:'AZ enforces bridge formula strictly on I-10, I-40' },
-  LA: { gvw:88000, single:20000, tandem:34000, note:'LA allows 88k GVW on National Highway System' },
-}
+};
 
 export default function AxleWeightCalculatorPage() {
-  const schema = { '@context':'https://schema.org','@type':'WebApplication', name:'Axle Weight Calculator — Federal Bridge Formula', url:'https://www.haulcommand.com/tools/axle-weight-calculator', description:'Calculate legal axle weights using the federal bridge formula. Free for all US states.', applicationCategory:'BusinessApplication', isAccessibleForFree:true, offers:{"@type":'Offer',price:'0',priceCurrency:'USD'} }
-  const faq = { '@context':'https://schema.org','@type':'FAQPage', mainEntity:[
-    {"@type":'Question', name:'What is the federal bridge formula?', acceptedAnswer:{"@type":'Answer', text:'The federal bridge formula (Federal Bridge Gross Weight Formula) limits the weight any set of axles can carry based on the spacing between them. Formula: W = 500 x (LN / (N-1) + 12N + 36), where W is the max weight in lbs, L is the distance in feet between the outer axles, and N is the number of axles.'}},
-    {"@type":'Question', name:'What is the maximum legal weight for a 5-axle semi-truck?', acceptedAnswer:{"@type":'Answer', text:'The federal maximum gross vehicle weight for a 5-axle semi-truck is 80,000 lbs. Individual axle limits are 20,000 lbs for a single axle and 34,000 lbs for a tandem axle group.'}},
-    {"@type":'Question', name:'Which state allows the most axle weight?', acceptedAnswer:{"@type":'Answer', text:'Michigan allows the highest gross vehicle weights in the United States, up to 164,000 lbs on qualified routes using the Michigan bridge formula and additional axles. Washington state allows up to 105,500 lbs on some routes.'}},
-  ]}
+  const schema = {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'Axle Weight Calculator',
+    url: 'https://www.haulcommand.com/tools/axle-weight-calculator',
+    description:
+      'Calculate Federal Bridge Formula axle-weight limits by axle count, outer bridge spacing, gross weight, and planning state.',
+    applicationCategory: 'BusinessApplication',
+    isAccessibleForFree: true,
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  };
+
+  const faq = {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: [
+      {
+        '@type': 'Question',
+        name: 'What is the Federal Bridge Formula?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: 'The Federal Bridge Formula limits how much weight an axle group can carry based on the distance between the outer axles and the number of axles in the group.',
+        },
+      },
+      {
+        '@type': 'Question',
+        name: 'Does a legal bridge-formula result guarantee a permitted route?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: 'No. A bridge-formula result is a planning screen. Final movement depends on the permit, bridge postings, state rules, route restrictions, and local authority conditions.',
+        },
+      },
+    ],
+  };
 
   return (
     <>
-      <JsonLd data={schema}/>
-      <JsonLd data={faq}/>
-      <div className=" bg-[#07090d] text-[#f0f2f5]">
-        <div className="border-b border-[#131c28] bg-gradient-to-r from-[#0a1929] to-[#07090d]">
-          <div className="px-4 lg:px-10 py-12 max-w-4xl mx-auto">
-            <p className="text-[11px] tracking-[0.2em] text-[#22c55e] font-semibold mb-3">FREE TOOL · NO LOGIN REQUIRED</p>
-            <h1 className="text-2xl lg:text-4xl font-extrabold text-[#f0f2f5] mb-4">Axle Weight Calculator — Federal Bridge Formula</h1>
-            <p className="text-sm text-[#8a9ab0] max-w-2xl">Check legal axle weight limits using the federal bridge formula. Select your axle configuration and state to see if your load is compliant — and if an overweight permit is required.</p>
-          </div>
-        </div>
-
-        <div className="px-4 lg:px-10 py-10 max-w-4xl mx-auto">
-
-          {/* AXLE CONFIGS REFERENCE */}
-          <div className="mb-10">
-            <h2 className="text-base font-bold text-[#f0f2f5] mb-4">Federal Legal Weight Limits by Axle Configuration</h2>
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-              {AXLE_CONFIGS.map(c=>(
-                <div key={c.label} className="bg-[#0f1a24] border border-[#1e3048] rounded-xl p-4">
-                  <p className="text-xs font-semibold text-[#d0dce8] mb-1">{c.label}</p>
-                  <p className="text-xl font-black text-[#22c55e]">{c.legal_lbs.toLocaleString()}</p>
-                  <p className="text-[10px] text-[#566880]">lbs legal max</p>
-                </div>
-              ))}
-            </div>
-            <p className="text-[10px] text-[#3a5068] mt-3">Federal limits. Some states allow higher weights with permits. Verify with state DOT before dispatch.</p>
-          </div>
-
-          {/* FEDERAL BRIDGE FORMULA */}
-          <div className="bg-[#0f1a24] border border-[#1e3048] rounded-2xl p-6 mb-10">
-            <h2 className="text-sm font-bold text-[#f0f2f5] mb-3">The Federal Bridge Formula</h2>
-            <div className="bg-[#07090d] rounded-xl p-4 mb-4 font-mono text-sm text-[#22c55e] text-center">
-              W = 500 × (LN ÷ (N−1) + 12N + 36)
-            </div>
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-3 text-xs">
-              <div className="bg-[#07090d] rounded-xl p-3"><span className="text-[#d4950e] font-bold">W</span> = Maximum weight in lbs that can be carried by the axle group</div>
-              <div className="bg-[#07090d] rounded-xl p-3"><span className="text-[#d4950e] font-bold">L</span> = Distance in feet between the outer axles of any group of 2 or more consecutive axles</div>
-              <div className="bg-[#07090d] rounded-xl p-3"><span className="text-[#d4950e] font-bold">N</span> = Number of axles in the group under consideration</div>
-            </div>
-          </div>
-
-          {/* STATE LIMITS TABLE */}
-          <div className="mb-10">
-            <h2 className="text-base font-bold text-[#f0f2f5] mb-4">State Weight Limits — Key States</h2>
-            <div className="overflow-x-auto">
-              <table className="w-full text-xs border-collapse">
-                <thead>
-                  <tr className="border-b border-[#1e3048]">
-                    {['State','GVW Limit','Single Axle','Tandem Axle','Notes'].map(h=>(
-                      <th key={h} className="text-left text-[#566880] font-semibold py-2 pr-4">{h}</th>
-                    ))}
-                  </tr>
-                </thead>
-                <tbody>
-                  {Object.entries(STATE_GVW).map(([state,d])=>(
-                    <tr key={state} className="border-b border-[#131c28] hover:bg-[#0f1a24]">
-                      <td className="py-2.5 pr-4 text-[#d0dce8] font-semibold">{state}</td>
-                      <td className="py-2.5 pr-4 text-[#8a9ab0]">{d.gvw.toLocaleString()} lbs</td>
-                      <td className="py-2.5 pr-4 text-[#8a9ab0]">{d.single.toLocaleString()} lbs</td>
-                      <td className="py-2.5 pr-4 text-[#8a9ab0]">{d.tandem.toLocaleString()} lbs</td>
-                      <td className="py-2.5 pr-4 text-[#566880]">{d.note}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-            <p className="text-[10px] text-[#3a5068] mt-3">Reference data verified Q1 2026. Confidence: <span className="text-[#d4950e]">partially_verified</span>. Always confirm with state DOT before dispatch.</p>
-          </div>
-
-          {/* FAQ */}
-          <div className="bg-[#0f1a24] border border-[#1e3048] rounded-2xl p-6 mb-8">
-            <h2 className="text-sm font-bold text-[#f0f2f5] mb-4">Axle Weight FAQs</h2>
-            <div className="space-y-3">
-              {[
-                {q:'What is the federal bridge formula?', a:'The federal bridge formula limits the weight any set of axles can carry based on the spacing between them. W = 500 × (LN ÷ (N−1) + 12N + 36). Where W = max weight (lbs), L = distance between outer axles (ft), N = number of axles. It protects bridges from overloading.'},
-                {q:'What is the maximum legal weight for a 5-axle semi?', a:'The federal cap is 80,000 lbs gross. Single axle: 20,000 lbs. Tandem axle: 34,000 lbs. Many states match federal limits. Michigan and Washington allow higher weights on specific routes with permits.'},
-                {q:'What happens if I exceed axle weight limits?', a:'Overweight loads require permits in every state you travel through. Without a permit, you risk fines of $100"“$5,000+ per violation, load rejection at weigh stations, and potential bridge damage liability.'},
-                {q:'Do pilot cars have their own weight requirements?', a:'Pilot cars and escort vehicles must comply with standard highway vehicle weight limits. They are not exempt from axle weight regulations and must have valid registration.'},
-              ].map((item,i)=>(
-                <details key={i} className="border border-[#131c28] rounded-xl p-4">
-                  <summary className="text-sm font-semibold text-[#d0dce8] cursor-pointer list-none flex justify-between">{item.q}<span className="text-[#566880] ml-3">+</span></summary>
-                  <p className="text-sm text-[#8a9ab0] mt-3 leading-relaxed">{item.a}</p>
-                </details>
-              ))}
-            </div>
-          </div>
-
-          <div className="flex flex-wrap gap-3">
-            {[['/tools/permit-cost-calculator','Permit Cost Calculator'],['/tools/superload-calculator','Superload Calculator'],['/tools/load-dimension-checker','Load Dimension Checker'],['/tools/frost-law-tracker','Frost Law Tracker']].map(([href,label])=>(
-              <Link key={href} href={href} className="text-xs bg-[#0f1a24] border border-[#1e3048] text-[#8ab0d0] px-3 py-2 rounded-lg hover:border-[#22c55e] hover:text-[#22c55e]">{label} →</Link>
-            ))}
-          </div>
-        </div>
-      </div>
+      <JsonLd data={schema} />
+      <JsonLd data={faq} />
+      <AxleWeightCalculatorClient />
     </>
-  )
+  );
 }

--- a/lib/tools/axleWeight.ts
+++ b/lib/tools/axleWeight.ts
@@ -1,0 +1,76 @@
+export type AxleWeightInput = {
+  axleCount: number;
+  outerBridgeFeet: number;
+  grossWeightLbs: number;
+  singleAxleMaxLbs: number;
+  tandemAxleMaxLbs: number;
+  stateCode: string;
+};
+
+export type AxleWeightResult = {
+  bridgeLimitLbs: number;
+  federalGrossCapLbs: number;
+  controllingLimitLbs: number;
+  overByLbs: number;
+  underByLbs: number;
+  status: 'legal' | 'over_bridge_limit';
+  permitLikelyRequired: boolean;
+  summary: string;
+};
+
+export type StateWeightLimit = {
+  code: string;
+  name: string;
+  gvwLimitLbs: number;
+  singleAxleLbs: number;
+  tandemAxleLbs: number;
+  note: string;
+};
+
+export const STATE_WEIGHT_LIMITS: StateWeightLimit[] = [
+  { code: 'US', name: 'Federal baseline', gvwLimitLbs: 80000, singleAxleLbs: 20000, tandemAxleLbs: 34000, note: 'Federal bridge formula baseline for interstate planning.' },
+  { code: 'AZ', name: 'Arizona', gvwLimitLbs: 80000, singleAxleLbs: 20000, tandemAxleLbs: 34000, note: 'Bridge formula enforcement is common on I-10 and I-40 corridors.' },
+  { code: 'CA', name: 'California', gvwLimitLbs: 80000, singleAxleLbs: 20000, tandemAxleLbs: 34000, note: 'Strict enforcement. Confirm permit conditions with Caltrans.' },
+  { code: 'FL', name: 'Florida', gvwLimitLbs: 80000, singleAxleLbs: 22000, tandemAxleLbs: 44000, note: 'State-road allowances can differ from interstate rules.' },
+  { code: 'LA', name: 'Louisiana', gvwLimitLbs: 88000, singleAxleLbs: 20000, tandemAxleLbs: 34000, note: 'Some routes allow higher gross weights with proper authority.' },
+  { code: 'MI', name: 'Michigan', gvwLimitLbs: 164000, singleAxleLbs: 18000, tandemAxleLbs: 32000, note: 'Michigan uses route-specific axle allowances and extra axles.' },
+  { code: 'NY', name: 'New York', gvwLimitLbs: 80000, singleAxleLbs: 22400, tandemAxleLbs: 36000, note: 'NYSDOT may apply state-specific bridge rules and permit conditions.' },
+  { code: 'OH', name: 'Ohio', gvwLimitLbs: 80000, singleAxleLbs: 20000, tandemAxleLbs: 34000, note: 'Seasonal and local restrictions can change practical routing.' },
+  { code: 'PA', name: 'Pennsylvania', gvwLimitLbs: 80000, singleAxleLbs: 20000, tandemAxleLbs: 34000, note: 'Certified-scale and route restrictions should be checked before dispatch.' },
+  { code: 'TX', name: 'Texas', gvwLimitLbs: 80000, singleAxleLbs: 25000, tandemAxleLbs: 46000, note: 'State allowances and permits vary by highway class.' },
+  { code: 'WA', name: 'Washington', gvwLimitLbs: 105500, singleAxleLbs: 20000, tandemAxleLbs: 34000, note: 'Higher gross weights may be available on selected routes.' },
+];
+
+export function getStateWeightLimit(code: string): StateWeightLimit {
+  return STATE_WEIGHT_LIMITS.find((state) => state.code === code) ?? STATE_WEIGHT_LIMITS[0]!;
+}
+
+export function calculateFederalBridgeLimit(axleCount: number, outerBridgeFeet: number): number {
+  if (axleCount <= 1) return 20000;
+  const raw = 500 * ((outerBridgeFeet * axleCount) / (axleCount - 1) + 12 * axleCount + 36);
+  return Math.floor(raw / 500) * 500;
+}
+
+export function evaluateAxleWeight(input: AxleWeightInput): AxleWeightResult {
+  const bridgeLimitLbs = calculateFederalBridgeLimit(input.axleCount, input.outerBridgeFeet);
+  const federalGrossCapLbs = input.axleCount >= 5 ? 80000 : bridgeLimitLbs;
+  const state = getStateWeightLimit(input.stateCode);
+  const controllingLimitLbs = Math.min(bridgeLimitLbs, Math.max(federalGrossCapLbs, state.gvwLimitLbs));
+  const overByLbs = Math.max(0, input.grossWeightLbs - controllingLimitLbs);
+  const underByLbs = Math.max(0, controllingLimitLbs - input.grossWeightLbs);
+  const status = overByLbs > 0 ? 'over_bridge_limit' : 'legal';
+
+  return {
+    bridgeLimitLbs,
+    federalGrossCapLbs,
+    controllingLimitLbs,
+    overByLbs,
+    underByLbs,
+    status,
+    permitLikelyRequired: overByLbs > 0 || input.grossWeightLbs > state.gvwLimitLbs,
+    summary:
+      status === 'legal'
+        ? `This axle group is ${underByLbs.toLocaleString()} lb under the controlling planning limit.`
+        : `This axle group is ${overByLbs.toLocaleString()} lb over the controlling planning limit.`,
+  };
+}

--- a/tests/unit/axle-weight-calculator.test.ts
+++ b/tests/unit/axle-weight-calculator.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { calculateFederalBridgeLimit, evaluateAxleWeight } from '@/lib/tools/axleWeight';
+
+describe('axle weight calculator', () => {
+  it('calculates the federal bridge formula for a standard five axle group', () => {
+    expect(calculateFederalBridgeLimit(5, 51)).toBe(79500);
+  });
+
+  it('marks an overweight move as permit likely', () => {
+    const result = evaluateAxleWeight({
+      axleCount: 6,
+      outerBridgeFeet: 55,
+      grossWeightLbs: 96000,
+      singleAxleMaxLbs: 20000,
+      tandemAxleMaxLbs: 34000,
+      stateCode: 'US',
+    });
+
+    expect(result.status).toBe('over_bridge_limit');
+    expect(result.permitLikelyRequired).toBe(true);
+    expect(result.overByLbs).toBeGreaterThan(0);
+  });
+
+  it('keeps a baseline legal move under the planning limit', () => {
+    const result = evaluateAxleWeight({
+      axleCount: 5,
+      outerBridgeFeet: 51,
+      grossWeightLbs: 78000,
+      singleAxleMaxLbs: 20000,
+      tandemAxleMaxLbs: 34000,
+      stateCode: 'US',
+    });
+
+    expect(result.status).toBe('legal');
+    expect(result.underByLbs).toBe(1500);
+  });
+});


### PR DESCRIPTION
## Summary
- Replaces the static axle-weight reference page with a real interactive Federal Bridge Formula calculator.
- Adds a reusable axle-weight engine for bridge-formula limits, controlling planning limits, over/under weight status, and permit signal.
- Preserves state planning-limit reference content and connects results to permit, dimension, and directory next actions.
- Adds focused unit tests for bridge formula and legal/overweight states.

## Verification
- `npm test -- tests/unit/axle-weight-calculator.test.ts tests/unit/certification-reciprocity-checker.test.ts`
- `npm run typecheck`
- `npm run build`