### PR TITLE
Suppress generic hero on live tool pages

### DIFF
--- a/app/(public)/tools/cross-border/page.tsx
+++ b/app/(public)/tools/cross-border/page.tsx
@@ -37,7 +37,7 @@ export default function CrossBorderCommandCenter() {
   ];
 
   return (
-    <div className=" bg-hc-bg text-hc-text font-display flex flex-col pt-[80px]">
+    <div data-hc-topic-hero="manual" className=" bg-hc-bg text-hc-text font-display flex flex-col pt-[80px]">
       {/* Header */}
       <div className="border-b border-hc-border bg-hc-surface/50 backdrop-blur-xl sticky top-[80px] z-30">
         <div className="max-w-7xl mx-auto px-4 py-8">

--- a/app/(public)/tools/oversize-load-checker/page.tsx
+++ b/app/(public)/tools/oversize-load-checker/page.tsx
@@ -21,7 +21,7 @@ const SCHEMA = {
 
 export default function OversizeLoadCheckerPage() {
   return (
-    <div className="min-h-screen bg-[#0B0F14] text-white">
+    <div data-hc-topic-hero="manual" className="min-h-screen bg-[#0B0F14] text-white">
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(SCHEMA) }} />
 
       {/* Command Surface Hero */}


### PR DESCRIPTION
## Summary
- suppress the global TopicHeroRouteSlot on the live cross-border and oversize-load checker pages
- removes the injected generic tool-detail copy and "Run this tool" CTA from pages that already have their own tool UI

## Verification
- npm run typecheck
- npm run build

Build passed. Existing warnings remain from project environment/runtime configuration, not this change.