### PR TITLE
Build oversize load checker engine

### DIFF
--- a/app/(public)/tools/oversize-load-checker/OversizeLoadCheckerClient.tsx
+++ b/app/(public)/tools/oversize-load-checker/OversizeLoadCheckerClient.tsx
@@ -1,0 +1,235 @@
+'use client';
+
+import Link from 'next/link';
+import { useMemo, useState } from 'react';
+import {
+  assessOversizeLoad,
+  OVERSIZE_LIMITS,
+  type OversizeJurisdictionCode,
+} from '@/lib/tools/oversizeLoad';
+
+const PRESETS = [
+  { label: 'Legal dry van', widthFeet: 8.5, heightFeet: 13.5, lengthFeet: 53, grossWeightLbs: 78000 },
+  { label: 'Wide excavator', widthFeet: 12, heightFeet: 13.8, lengthFeet: 62, grossWeightLbs: 92000 },
+  { label: 'Tall transformer', widthFeet: 11, heightFeet: 15.2, lengthFeet: 70, grossWeightLbs: 148000 },
+  { label: 'Superload screen', widthFeet: 17, heightFeet: 16, lengthFeet: 120, grossWeightLbs: 240000 },
+];
+
+function formatNumber(value: number) {
+  return new Intl.NumberFormat('en-US').format(value);
+}
+
+export function OversizeLoadCheckerClient() {
+  const [jurisdiction, setJurisdiction] = useState<OversizeJurisdictionCode>('US');
+  const [widthFeet, setWidthFeet] = useState(12);
+  const [heightFeet, setHeightFeet] = useState(14);
+  const [lengthFeet, setLengthFeet] = useState(70);
+  const [grossWeightLbs, setGrossWeightLbs] = useState(92000);
+
+  const assessment = useMemo(
+    () =>
+      assessOversizeLoad({
+        jurisdiction,
+        widthFeet,
+        heightFeet,
+        lengthFeet,
+        grossWeightLbs,
+      }),
+    [grossWeightLbs, heightFeet, jurisdiction, lengthFeet, widthFeet],
+  );
+
+  const statusColor =
+    assessment.status === 'legal'
+      ? '#22c55e'
+      : assessment.status === 'permit_required'
+        ? '#F1A91B'
+        : assessment.status === 'escort_likely'
+          ? '#f97316'
+          : '#ef4444';
+
+  return (
+    <main data-hc-topic-hero="manual" className="min-h-screen bg-[#0B0F14] text-white">
+      <section className="border-b border-[#F1A91B]/10 bg-[#071019]">
+        <div className="mx-auto max-w-6xl px-4 py-12">
+          <div className="mb-4 flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-[#F1A91B]">
+            <Link href="/tools" className="hover:text-white">
+              Tools
+            </Link>
+            <span>/</span>
+            <span>Load Classification</span>
+          </div>
+          <h1 className="mb-3 text-4xl font-black">Oversize Load Checker</h1>
+          <p className="max-w-2xl text-lg leading-relaxed text-gray-400">
+            Enter dimensions and gross weight to screen permit triggers, pilot-car needs, high-pole risk, and superload review signals before dispatch.
+          </p>
+        </div>
+      </section>
+
+      <section className="mx-auto grid max-w-6xl gap-6 px-4 py-10 lg:grid-cols-[420px_1fr]">
+        <div className="space-y-5">
+          <div className="rounded-2xl border border-white/[0.08] bg-[#111827] p-6">
+            <h2 className="mb-5 text-sm font-black uppercase tracking-wider">Load Inputs</h2>
+            <div className="space-y-4">
+              <label className="block">
+                <span className="mb-1.5 block text-xs font-bold uppercase tracking-wider text-gray-500">Planning jurisdiction</span>
+                <select
+                  value={jurisdiction}
+                  onChange={(event) => setJurisdiction(event.target.value as OversizeJurisdictionCode)}
+                  className="w-full rounded-xl border border-white/10 bg-[#0B0F14] px-3 py-3 text-sm text-white outline-none focus:border-[#F1A91B]"
+                >
+                  {OVERSIZE_LIMITS.map((profile) => (
+                    <option key={profile.code} value={profile.code}>
+                      {profile.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              {[
+                { label: 'Width (ft)', value: widthFeet, set: setWidthFeet, min: 0, step: 0.1 },
+                { label: 'Height (ft)', value: heightFeet, set: setHeightFeet, min: 0, step: 0.1 },
+                { label: 'Length (ft)', value: lengthFeet, set: setLengthFeet, min: 0, step: 1 },
+                { label: 'Gross weight (lb)', value: grossWeightLbs, set: setGrossWeightLbs, min: 0, step: 1000 },
+              ].map((field) => (
+                <label key={field.label} className="block">
+                  <span className="mb-1.5 block text-xs font-bold uppercase tracking-wider text-gray-500">{field.label}</span>
+                  <input
+                    type="number"
+                    min={field.min}
+                    step={field.step}
+                    value={field.value}
+                    onChange={(event) => field.set(Number(event.target.value))}
+                    className="w-full rounded-xl border border-white/10 bg-[#0B0F14] px-3 py-3 text-sm text-white outline-none focus:border-[#F1A91B]"
+                  />
+                </label>
+              ))}
+            </div>
+          </div>
+
+          <div className="rounded-2xl border border-white/[0.08] bg-[#111827] p-6">
+            <h2 className="mb-4 text-sm font-black uppercase tracking-wider">Common presets</h2>
+            <div className="grid gap-2">
+              {PRESETS.map((preset) => (
+                <button
+                  key={preset.label}
+                  type="button"
+                  onClick={() => {
+                    setWidthFeet(preset.widthFeet);
+                    setHeightFeet(preset.heightFeet);
+                    setLengthFeet(preset.lengthFeet);
+                    setGrossWeightLbs(preset.grossWeightLbs);
+                  }}
+                  className="rounded-xl border border-white/[0.08] bg-[#0B0F14] px-3 py-3 text-left text-sm text-gray-300 hover:border-[#F1A91B]/40 hover:text-white"
+                >
+                  <span className="block font-bold text-white">{preset.label}</span>
+                  {preset.widthFeet} ft W / {preset.heightFeet} ft H / {preset.lengthFeet} ft L / {formatNumber(preset.grossWeightLbs)} lb
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="space-y-6">
+          <div className="rounded-2xl border border-white/[0.08] bg-[#111827] p-6">
+            <div className="mb-5 flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+              <div>
+                <p className="mb-2 text-xs font-bold uppercase tracking-widest text-gray-500">Result</p>
+                <h2 className="text-3xl font-black" style={{ color: statusColor }}>
+                  {assessment.statusLabel}
+                </h2>
+                <p className="mt-3 max-w-2xl text-sm leading-relaxed text-gray-400">{assessment.summary}</p>
+              </div>
+              <div className="rounded-xl border border-white/10 bg-[#0B0F14] px-4 py-3 text-right">
+                <p className="text-xs uppercase tracking-wider text-gray-500">Escorts</p>
+                <p className="text-2xl font-black text-white">{assessment.escortCountEstimate}</p>
+              </div>
+            </div>
+
+            <div className="grid gap-3 md:grid-cols-4">
+              {[
+                ['Permit', assessment.permitRequired ? 'Likely' : 'Not flagged'],
+                ['High pole', assessment.highPoleLikely ? 'Likely' : 'Not flagged'],
+                ['Police escort', assessment.policeEscortLikely ? 'Possible' : 'Not flagged'],
+                ['Superload review', assessment.superloadReviewLikely ? 'Likely' : 'Not flagged'],
+              ].map(([label, value]) => (
+                <div key={label} className="rounded-xl border border-white/[0.06] bg-[#0B0F14] p-4">
+                  <p className="text-[11px] font-bold uppercase tracking-wider text-gray-500">{label}</p>
+                  <p className="mt-1 text-sm font-black text-white">{value}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="rounded-2xl border border-white/[0.08] bg-[#111827] p-6">
+            <h2 className="mb-4 text-sm font-black uppercase tracking-wider">Exceeded Limits</h2>
+            {assessment.exceeded.length ? (
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead className="text-left text-xs uppercase tracking-wider text-gray-500">
+                    <tr>
+                      <th className="pb-3">Field</th>
+                      <th className="pb-3">Actual</th>
+                      <th className="pb-3">Planning limit</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-white/[0.06]">
+                    {assessment.exceeded.map((row) => (
+                      <tr key={row.field}>
+                        <td className="py-3 font-bold text-white">{row.field}</td>
+                        <td className="py-3 text-[#F1A91B]">
+                          {formatNumber(row.actual)} {row.unit}
+                        </td>
+                        <td className="py-3 text-gray-400">
+                          {formatNumber(row.limit)} {row.unit}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : (
+              <p className="text-sm text-gray-400">No entered value exceeds the selected planning profile.</p>
+            )}
+          </div>
+
+          <div className="rounded-2xl border border-[#F1A91B]/20 bg-[#F1A91B]/5 p-6">
+            <h2 className="mb-4 text-sm font-black uppercase tracking-wider text-[#F1A91B]">Next actions</h2>
+            <ol className="space-y-3 text-sm leading-relaxed text-gray-300">
+              {assessment.nextActions.map((action) => (
+                <li key={action} className="rounded-xl border border-[#F1A91B]/10 bg-[#0B0F14] p-3">
+                  {action}
+                </li>
+              ))}
+            </ol>
+          </div>
+
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            {[
+              ['/tools/escort-count-calculator', 'Escort Count'],
+              ['/tools/axle-weight-calculator', 'Axle Weight'],
+              ['/tools/pilot-car-rate-calculator', 'Pilot Car Rate'],
+              ['/directory', 'Find Operators'],
+            ].map(([href, label]) => (
+              <Link
+                key={href}
+                href={href}
+                className="rounded-xl border border-white/[0.08] bg-[#111827] px-4 py-3 text-center text-sm font-bold text-gray-300 hover:border-[#F1A91B]/40 hover:text-[#F1A91B]"
+              >
+                {label}
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-6xl px-4 pb-12">
+        <div className="rounded-2xl border border-white/[0.08] bg-[#111827] p-6">
+          <h2 className="mb-3 text-sm font-black uppercase tracking-wider">Authority note</h2>
+          <p className="text-sm leading-relaxed text-gray-400">
+            This is a planning screen, not an official permit decision. Final requirements come from the active permit, route survey, bridge postings, local movement restrictions, and the issuing authority for each jurisdiction.
+          </p>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app/(public)/tools/oversize-load-checker/page.tsx
+++ b/app/(public)/tools/oversize-load-checker/page.tsx
@@ -1,19 +1,19 @@
 import type { Metadata } from 'next';
-import Link from 'next/link';
+import { OversizeLoadCheckerClient } from './OversizeLoadCheckerClient';
 
 export const metadata: Metadata = {
-  title: 'Oversize Load Checker — Is My Load Oversize? | Haul Command',
-  description: 'Check whether your load may be legally oversize in supported markets. Enter width, height, length and get permit and escort requirements.',
+  title: 'Oversize Load Checker - Permit & Escort Screen | Haul Command',
+  description:
+    'Enter width, height, length and weight to screen oversize permit triggers, pilot car needs, high-pole risk, and superload review signals.',
   alternates: { canonical: 'https://www.haulcommand.com/tools/oversize-load-checker' },
 };
 
-// US state legal limits
-const US_LIMITS = { width_ft: 8.5, height_ft: 13.5, length_ft: 65, weight_lbs: 80000 };
-
-const SCHEMA = {
-  '@context': 'https://schema.org', '@type': 'WebApplication',
+const schema = {
+  '@context': 'https://schema.org',
+  '@type': 'WebApplication',
   name: 'Haul Command Oversize Load Checker',
-  description: 'Check if your load exceeds legal oversize thresholds by state',
+  description:
+    'Screen oversize permit, escort, high-pole, and superload review triggers from load dimensions and gross weight.',
   url: 'https://www.haulcommand.com/tools/oversize-load-checker',
   applicationCategory: 'BusinessApplication',
   offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
@@ -21,113 +21,9 @@ const SCHEMA = {
 
 export default function OversizeLoadCheckerPage() {
   return (
-    <div data-hc-topic-hero="manual" className="min-h-screen bg-[#0B0F14] text-white">
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(SCHEMA) }} />
-
-      {/* Command Surface Hero */}
-      <div className="border-b border-[#F1A91B]/10" style={{ background: 'linear-gradient(135deg, #0B0F14 0%, #0f1a24 100%)' }}>
-        <div className="max-w-4xl mx-auto px-4 py-12">
-          <div className="flex items-center gap-2 text-xs text-[#F1A91B] font-bold uppercase tracking-widest mb-4">
-            <Link href="/tools" className="hover:text-white transition-colors">Tools</Link>
-            <span>›</span>
-            <span>Load Classification</span>
-          </div>
-          <h1 className="text-4xl font-black mb-3">Oversize Load Checker</h1>
-          <p className="text-gray-400 text-lg max-w-xl">Enter your load dimensions to review if you need oversize permits, pilot cars, or special routing — in supported markets.</p>
-        </div>
-      </div>
-
-      <div className="max-w-4xl mx-auto px-4 py-10">
-        {/* Interactive calculator shell — client component needed for full interactivity */}
-        {/* Server-side version shows the decision logic + thresholds */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-10">
-          {/* Threshold reference */}
-          <div className="bg-[#111827] border border-white/[0.08] rounded-2xl p-6">
-            <h2 className="font-black text-white mb-4">US Standard Legal Limits</h2>
-            <div className="space-y-3">
-              {[
-                { label: 'Width', value: '8.5 ft (102 in)', icon: '↔️', trigger: '> 8.5 ft → oversize permit required in all 50 states' },
-                { label: 'Height', value: '13.5 ft', icon: '↕️', trigger: '> 13.5 ft → route survey required in most states' },
-                { label: 'Length', value: '65 ft', icon: '↔️', trigger: '> 65 ft → rear escort required in most states' },
-                { label: 'Gross Weight', value: '80,000 lbs', icon: '⚖️', trigger: '> 80,000 lbs → overweight permit required' },
-              ].map(t => (
-                <div key={t.label} className="p-3 bg-[#0d1117] rounded-xl border border-white/[0.04]">
-                  <div className="flex items-center justify-between mb-1">
-                    <span className="text-xs font-bold text-gray-400 uppercase tracking-wider">{t.icon} {t.label}</span>
-                    <span className="text-sm font-black text-[#F1A91B]">{t.value}</span>
-                  </div>
-                  <p className="text-xs text-gray-500">{t.trigger}</p>
-                </div>
-              ))}
-            </div>
-          </div>
-
-          {/* Result calculator — quick reference */}
-          <div className="bg-[#111827] border border-[#F1A91B]/20 rounded-2xl p-6">
-            <h2 className="font-black text-white mb-4">Quick Classification</h2>
-            <p className="text-sm text-gray-400 mb-5">Based on your dimensions, your load falls into one of these categories:</p>
-            <div className="space-y-3">
-              {[
-                { label: 'Standard Legal', range: 'Within all limits', color: '#22c55e', needs: 'No permit required' },
-                { label: 'Oversize Class I', range: 'Up to 12 ft wide', color: '#F1A91B', needs: 'Permit + 1 pilot car' },
-                { label: 'Oversize Class II', range: 'Up to 14 ft wide', color: '#f97316', needs: 'Permit + 2 pilot cars' },
-                { label: 'Superload', range: '> 16 ft wide / 200k lbs', color: '#ef4444', needs: 'Special routing + engineering review' },
-              ].map(c => (
-                <div key={c.label} className="flex items-center gap-3 p-3 bg-[#0d1117] rounded-xl border border-white/[0.04]">
-                  <div className="w-2.5 h-2.5 rounded-full shrink-0" style={{ background: c.color }} />
-                  <div className="flex-1">
-                    <div className="text-sm font-bold text-white">{c.label}</div>
-                    <div className="text-xs text-gray-500">{c.range}</div>
-                  </div>
-                  <div className="text-xs font-semibold text-gray-400">{c.needs}</div>
-                </div>
-              ))}
-            </div>
-            <div className="mt-5 pt-5 border-t border-white/[0.06]">
-              <Link href="/tools/escort-count-calculator" className="block text-center py-2.5 bg-[#F1A91B] hover:bg-[#D4951A] text-black font-bold rounded-xl text-sm transition-colors">
-                Calculate Escort Count →
-              </Link>
-            </div>
-          </div>
-        </div>
-
-        {/* State-by-state context */}
-        <div className="bg-[#111827] border border-white/[0.08] rounded-2xl p-6 mb-8">
-          <h2 className="font-black text-xl mb-4">Why Width Triggers Change by State</h2>
-          <p className="text-gray-400 text-sm leading-relaxed mb-4">The 8.5 ft standard is federal, but states add their own escort trigger thresholds. Texas requires a pilot car at 12 ft wide; California requires one at 10 ft; Arizona requires one at 14 ft. Some states require police escorts above 16 ft regardless of permit.</p>
-          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
-            {[
-              { state: 'TX', pilot_at: '12 ft wide' }, { state: 'CA', pilot_at: '10 ft wide' },
-              { state: 'FL', pilot_at: '12 ft wide' }, { state: 'LA', pilot_at: '12 ft wide' },
-              { state: 'OH', pilot_at: '12 ft wide' }, { state: 'AZ', pilot_at: '14 ft wide' },
-            ].map(s => (
-              <div key={s.state} className="p-3 bg-[#0d1117] rounded-xl text-center">
-                <div className="text-lg font-black text-[#F1A91B]">{s.state}</div>
-                <div className="text-xs text-gray-500 mt-0.5">Pilot car @ {s.pilot_at}</div>
-              </div>
-            ))}
-          </div>
-        </div>
-
-        {/* Interlinking */}
-        <div className="bg-[#111827] border border-white/[0.06] rounded-2xl p-6">
-          <h3 className="font-black text-lg mb-2">Next Steps</h3>
-          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
-            {[
-              { href: '/tools/escort-requirement-checker', label: 'Escort Requirements', icon: '⚖️' },
-              { href: '/tools/permit-cost-calculator', label: 'Permit Costs', icon: '📋' },
-              { href: '/tools/escort-count-calculator', label: 'Escort Count', icon: '🚗' },
-              { href: '/tools/total-trip-cost-calculator', label: 'Total Trip Cost', icon: '💰' },
-              { href: '/directory', label: 'Find Escorts', icon: '🔍' },
-              { href: '/glossary', label: 'Glossary', icon: '📖' },
-            ].map(l => (
-              <Link key={l.href} href={l.href} className="flex items-center gap-2 p-3 bg-[#0d1117] hover:bg-[#F1A91B]/5 border border-white/[0.04] hover:border-[#F1A91B]/20 rounded-xl text-xs font-semibold text-gray-400 hover:text-[#F1A91B] transition-all">
-                <span>{l.icon}</span>{l.label}
-              </Link>
-            ))}
-          </div>
-        </div>
-      </div>
-    </div>
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }} />
+      <OversizeLoadCheckerClient />
+    </>
   );
 }

--- a/lib/tools/oversizeLoad.ts
+++ b/lib/tools/oversizeLoad.ts
@@ -1,0 +1,254 @@
+export type OversizeJurisdictionCode = 'US' | 'AZ' | 'CA' | 'FL' | 'LA' | 'MI' | 'NY' | 'OH' | 'PA' | 'TX' | 'WA';
+
+export type OversizeInput = {
+  jurisdiction: OversizeJurisdictionCode;
+  widthFeet: number;
+  heightFeet: number;
+  lengthFeet: number;
+  grossWeightLbs: number;
+};
+
+export type OversizeLimitProfile = {
+  code: OversizeJurisdictionCode;
+  label: string;
+  maxWidthFeet: number;
+  maxHeightFeet: number;
+  maxLengthFeet: number;
+  maxGrossWeightLbs: number;
+  escortWidthOneFeet: number;
+  escortWidthTwoFeet: number;
+  highPoleHeightFeet: number;
+  superloadWidthFeet: number;
+  superloadWeightLbs: number;
+  note: string;
+};
+
+export type OversizeAssessment = {
+  jurisdiction: OversizeLimitProfile;
+  status: 'legal' | 'permit_required' | 'escort_likely' | 'superload_review';
+  statusLabel: string;
+  permitRequired: boolean;
+  escortCountEstimate: number;
+  highPoleLikely: boolean;
+  policeEscortLikely: boolean;
+  superloadReviewLikely: boolean;
+  exceeded: Array<{ field: string; actual: number; limit: number; unit: string }>;
+  summary: string;
+  nextActions: string[];
+};
+
+export const OVERSIZE_LIMITS: OversizeLimitProfile[] = [
+  {
+    code: 'US',
+    label: 'Federal baseline (US)',
+    maxWidthFeet: 8.5,
+    maxHeightFeet: 13.5,
+    maxLengthFeet: 65,
+    maxGrossWeightLbs: 80000,
+    escortWidthOneFeet: 12,
+    escortWidthTwoFeet: 14,
+    highPoleHeightFeet: 14.5,
+    superloadWidthFeet: 16,
+    superloadWeightLbs: 200000,
+    note: 'Baseline planning screen. State permits and route restrictions control the final move.',
+  },
+  {
+    code: 'AZ',
+    label: 'Arizona (AZ)',
+    maxWidthFeet: 8.5,
+    maxHeightFeet: 14,
+    maxLengthFeet: 65,
+    maxGrossWeightLbs: 80000,
+    escortWidthOneFeet: 14,
+    escortWidthTwoFeet: 16,
+    highPoleHeightFeet: 15,
+    superloadWidthFeet: 16,
+    superloadWeightLbs: 250000,
+    note: 'Arizona commonly uses high-pole and route review thresholds for taller loads.',
+  },
+  {
+    code: 'CA',
+    label: 'California (CA)',
+    maxWidthFeet: 8.5,
+    maxHeightFeet: 14,
+    maxLengthFeet: 65,
+    maxGrossWeightLbs: 80000,
+    escortWidthOneFeet: 10,
+    escortWidthTwoFeet: 12,
+    highPoleHeightFeet: 14.5,
+    superloadWidthFeet: 15,
+    superloadWeightLbs: 200000,
+    note: 'California is stricter than the federal baseline on many escort and route conditions.',
+  },
+  {
+    code: 'FL',
+    label: 'Florida (FL)',
+    maxWidthFeet: 8.5,
+    maxHeightFeet: 13.5,
+    maxLengthFeet: 65,
+    maxGrossWeightLbs: 80000,
+    escortWidthOneFeet: 12,
+    escortWidthTwoFeet: 14,
+    highPoleHeightFeet: 15,
+    superloadWidthFeet: 16,
+    superloadWeightLbs: 200000,
+    note: 'Florida escort triggers vary by roadway, metro area, and permit conditions.',
+  },
+  {
+    code: 'LA',
+    label: 'Louisiana (LA)',
+    maxWidthFeet: 8.5,
+    maxHeightFeet: 13.5,
+    maxLengthFeet: 65,
+    maxGrossWeightLbs: 88000,
+    escortWidthOneFeet: 12,
+    escortWidthTwoFeet: 14,
+    highPoleHeightFeet: 15,
+    superloadWidthFeet: 16,
+    superloadWeightLbs: 232000,
+    note: 'Bridge postings, parish rules, and flood/weather events can change Louisiana routing.',
+  },
+  {
+    code: 'MI',
+    label: 'Michigan (MI)',
+    maxWidthFeet: 8.5,
+    maxHeightFeet: 13.5,
+    maxLengthFeet: 65,
+    maxGrossWeightLbs: 164000,
+    escortWidthOneFeet: 12,
+    escortWidthTwoFeet: 14,
+    highPoleHeightFeet: 14.5,
+    superloadWidthFeet: 16,
+    superloadWeightLbs: 200000,
+    note: 'Michigan axle configurations can allow higher GVW, but permit and bridge rules still control.',
+  },
+  {
+    code: 'NY',
+    label: 'New York (NY)',
+    maxWidthFeet: 8.5,
+    maxHeightFeet: 13.5,
+    maxLengthFeet: 65,
+    maxGrossWeightLbs: 80000,
+    escortWidthOneFeet: 12,
+    escortWidthTwoFeet: 14,
+    highPoleHeightFeet: 14.5,
+    superloadWidthFeet: 16,
+    superloadWeightLbs: 200000,
+    note: 'New York City, parkways, bridges, and tunnels require separate route screening.',
+  },
+  {
+    code: 'OH',
+    label: 'Ohio (OH)',
+    maxWidthFeet: 8.5,
+    maxHeightFeet: 13.5,
+    maxLengthFeet: 65,
+    maxGrossWeightLbs: 80000,
+    escortWidthOneFeet: 12,
+    escortWidthTwoFeet: 14,
+    highPoleHeightFeet: 14.5,
+    superloadWidthFeet: 16,
+    superloadWeightLbs: 200000,
+    note: 'Ohio turnpike and local route restrictions can change escort and timing requirements.',
+  },
+  {
+    code: 'PA',
+    label: 'Pennsylvania (PA)',
+    maxWidthFeet: 8.5,
+    maxHeightFeet: 13.5,
+    maxLengthFeet: 65,
+    maxGrossWeightLbs: 80000,
+    escortWidthOneFeet: 12,
+    escortWidthTwoFeet: 14,
+    highPoleHeightFeet: 14.5,
+    superloadWidthFeet: 16,
+    superloadWeightLbs: 201000,
+    note: 'Pennsylvania bridge, tunnel, and metro restrictions need route-level validation.',
+  },
+  {
+    code: 'TX',
+    label: 'Texas (TX)',
+    maxWidthFeet: 8.5,
+    maxHeightFeet: 14,
+    maxLengthFeet: 65,
+    maxGrossWeightLbs: 80000,
+    escortWidthOneFeet: 12,
+    escortWidthTwoFeet: 14,
+    highPoleHeightFeet: 17,
+    superloadWidthFeet: 16,
+    superloadWeightLbs: 254300,
+    note: 'Texas superheavy thresholds, DPS escorts, and curfews depend on corridor and permit class.',
+  },
+  {
+    code: 'WA',
+    label: 'Washington (WA)',
+    maxWidthFeet: 8.5,
+    maxHeightFeet: 14,
+    maxLengthFeet: 75,
+    maxGrossWeightLbs: 105500,
+    escortWidthOneFeet: 12,
+    escortWidthTwoFeet: 14,
+    highPoleHeightFeet: 14.5,
+    superloadWidthFeet: 16,
+    superloadWeightLbs: 200000,
+    note: 'Washington pilot/escort certification and route restrictions need permit-condition review.',
+  },
+];
+
+export function getOversizeLimitProfile(code: OversizeJurisdictionCode): OversizeLimitProfile {
+  return OVERSIZE_LIMITS.find((profile) => profile.code === code) ?? OVERSIZE_LIMITS[0];
+}
+
+export function assessOversizeLoad(input: OversizeInput): OversizeAssessment {
+  const profile = getOversizeLimitProfile(input.jurisdiction);
+  const exceeded = [
+    { field: 'Width', actual: input.widthFeet, limit: profile.maxWidthFeet, unit: 'ft' },
+    { field: 'Height', actual: input.heightFeet, limit: profile.maxHeightFeet, unit: 'ft' },
+    { field: 'Length', actual: input.lengthFeet, limit: profile.maxLengthFeet, unit: 'ft' },
+    { field: 'Gross weight', actual: input.grossWeightLbs, limit: profile.maxGrossWeightLbs, unit: 'lb' },
+  ].filter((row) => row.actual > row.limit);
+
+  const permitRequired = exceeded.length > 0;
+  const superloadReviewLikely =
+    input.widthFeet >= profile.superloadWidthFeet || input.grossWeightLbs >= profile.superloadWeightLbs;
+  const escortCountEstimate = input.widthFeet >= profile.escortWidthTwoFeet ? 2 : input.widthFeet >= profile.escortWidthOneFeet ? 1 : 0;
+  const highPoleLikely = input.heightFeet >= profile.highPoleHeightFeet;
+  const policeEscortLikely = superloadReviewLikely || input.widthFeet >= 16;
+
+  let status: OversizeAssessment['status'] = 'legal';
+  if (superloadReviewLikely) status = 'superload_review';
+  else if (escortCountEstimate > 0 || highPoleLikely || policeEscortLikely) status = 'escort_likely';
+  else if (permitRequired) status = 'permit_required';
+
+  const statusLabel = {
+    legal: 'Likely legal-size planning screen',
+    permit_required: 'Permit likely required',
+    escort_likely: 'Escort review likely required',
+    superload_review: 'Superload / engineering review likely',
+  }[status];
+
+  const nextActions = [
+    permitRequired ? 'Confirm oversize or overweight permit class with the issuing authority.' : 'Keep permit proof available if a local rule is stricter than the baseline.',
+    escortCountEstimate > 0 ? `Plan for at least ${escortCountEstimate} escort vehicle${escortCountEstimate > 1 ? 's' : ''} before quoting.` : 'Check corridor-specific escort triggers if the route crosses metro or restricted zones.',
+    highPoleLikely ? 'Screen vertical clearance and high-pole requirements before dispatch.' : 'Run vertical clearance checks if height approaches bridge or utility thresholds.',
+    superloadReviewLikely ? 'Budget time for engineering review, police escort coordination, and route survey.' : 'Re-check weight distribution with the axle-weight calculator.',
+  ];
+
+  const summary =
+    status === 'legal'
+      ? `This load is within the ${profile.label} baseline dimensions entered here.`
+      : `${exceeded.map((row) => row.field.toLowerCase()).join(', ')} exceed ${profile.label} planning limits.`;
+
+  return {
+    jurisdiction: profile,
+    status,
+    statusLabel,
+    permitRequired,
+    escortCountEstimate,
+    highPoleLikely,
+    policeEscortLikely,
+    superloadReviewLikely,
+    exceeded,
+    summary,
+    nextActions,
+  };
+}

--- a/tests/unit/oversize-load-checker.test.ts
+++ b/tests/unit/oversize-load-checker.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { assessOversizeLoad } from '@/lib/tools/oversizeLoad';
+
+describe('assessOversizeLoad', () => {
+  it('keeps a legal baseline load out of permit status', () => {
+    const result = assessOversizeLoad({
+      jurisdiction: 'US',
+      widthFeet: 8.5,
+      heightFeet: 13.5,
+      lengthFeet: 53,
+      grossWeightLbs: 78000,
+    });
+
+    expect(result.status).toBe('legal');
+    expect(result.permitRequired).toBe(false);
+    expect(result.escortCountEstimate).toBe(0);
+    expect(result.exceeded).toHaveLength(0);
+  });
+
+  it('flags permit and one escort for a 12-foot Texas load', () => {
+    const result = assessOversizeLoad({
+      jurisdiction: 'TX',
+      widthFeet: 12,
+      heightFeet: 13.8,
+      lengthFeet: 64,
+      grossWeightLbs: 79000,
+    });
+
+    expect(result.permitRequired).toBe(true);
+    expect(result.status).toBe('escort_likely');
+    expect(result.escortCountEstimate).toBe(1);
+    expect(result.exceeded.map((row) => row.field)).toContain('Width');
+  });
+
+  it('escalates wide and heavy loads into superload review', () => {
+    const result = assessOversizeLoad({
+      jurisdiction: 'CA',
+      widthFeet: 16,
+      heightFeet: 15,
+      lengthFeet: 100,
+      grossWeightLbs: 225000,
+    });
+
+    expect(result.status).toBe('superload_review');
+    expect(result.superloadReviewLikely).toBe(true);
+    expect(result.policeEscortLikely).toBe(true);
+    expect(result.highPoleLikely).toBe(true);
+    expect(result.escortCountEstimate).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- replace the static oversize-load checker page with a real interactive calculator
- add a reusable oversize load assessment engine for permit, escort, high-pole, police escort, and superload review signals
- add focused unit coverage for legal, escort-triggered, and superload cases

## Verification
- npm test -- tests/unit/oversize-load-checker.test.ts
- npm run typecheck
- npm run build

Build passed. Existing warnings remain from project environment/runtime configuration, not this change.