### PR TITLE
Build total trip cost calculator engine

### DIFF
--- a/app/(public)/tools/total-trip-cost-calculator/TotalTripCostCalculatorClient.tsx
+++ b/app/(public)/tools/total-trip-cost-calculator/TotalTripCostCalculatorClient.tsx
@@ -1,0 +1,248 @@
+'use client';
+
+import Link from 'next/link';
+import { useMemo, useState } from 'react';
+import {
+  calculateTotalTripCost,
+  totalTripComplexityLabels,
+  totalTripRegionLabels,
+  type TotalTripCostInput,
+  type TripComplexity,
+  type TripCostBenchmarks,
+  type TripCostRegion,
+} from '@/lib/tools/totalTripCost';
+
+const regions = Object.entries(totalTripRegionLabels) as [TripCostRegion, string][];
+const complexities = Object.entries(totalTripComplexityLabels) as [TripComplexity, string][];
+
+function money(value: number) {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+function NumberField({
+  label,
+  value,
+  min = 0,
+  max,
+  step = 1,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  min?: number;
+  max?: number;
+  step?: number;
+  onChange: (value: number) => void;
+}) {
+  return (
+    <label className="block">
+      <span className="text-xs font-bold uppercase tracking-wider text-slate-400">{label}</span>
+      <input
+        type="number"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(event) => onChange(Number(event.target.value))}
+        className="mt-2 w-full rounded-xl border border-white/10 bg-[#0B0F14] px-3 py-3 text-white outline-none focus:border-[#F1A91B]"
+      />
+    </label>
+  );
+}
+
+export function TotalTripCostCalculatorClient({ benchmarks }: { benchmarks: TripCostBenchmarks }) {
+  const [state, setState] = useState<Omit<TotalTripCostInput, 'benchmarks'>>({
+    miles: 1200,
+    jurisdictions: 4,
+    travelDays: 3,
+    escortCount: 2,
+    permitAverage: 350,
+    fuelMpg: 5.5,
+    dieselPrice: 4.25,
+    tolls: 250,
+    overnightNights: 2,
+    overnightRate: 140,
+    waitHours: 4,
+    policeHours: 0,
+    routeSurvey: false,
+    highPole: true,
+    region: 'texas_gulf',
+    complexity: 'overheight',
+  });
+
+  const result = useMemo(
+    () => calculateTotalTripCost({ ...state, benchmarks }),
+    [benchmarks, state],
+  );
+
+  const setNumber = (key: keyof Omit<TotalTripCostInput, 'benchmarks' | 'region' | 'complexity' | 'routeSurvey' | 'highPole'>) =>
+    (value: number) => setState((current) => ({ ...current, [key]: value }));
+
+  const costRows = [
+    ['Permits', result.permitCost],
+    ['Pilot cars / escorts', result.escortCost],
+    ['High-pole car', result.highPoleCost],
+    ['Fuel', result.fuelCost],
+    ['Tolls / access fees', result.tollCost],
+    ['Overnight / per diem', result.overnightCost],
+    ['Wait / detention', result.waitCost],
+    ['Police escort', result.policeCost],
+    ['Route survey', result.routeSurveyCost],
+    ['Planning contingency', result.contingency],
+  ];
+
+  return (
+    <div data-hc-topic-hero="manual" className="min-h-screen bg-[#0B0F14] text-white">
+      <section className="border-b border-[#F1A91B]/10 bg-[#0B0F14]">
+        <div className="mx-auto max-w-6xl px-4 py-12">
+          <div className="mb-4 flex items-center gap-2 text-xs font-bold uppercase tracking-[0.2em] text-[#F1A91B]">
+            <Link href="/tools" className="hover:text-white">Tools</Link>
+            <span>/</span>
+            <span>Cost Intelligence</span>
+          </div>
+          <h1 className="max-w-4xl text-3xl font-black tracking-tight md:text-5xl">
+            Total Trip Cost Calculator
+          </h1>
+          <p className="mt-4 max-w-3xl text-base leading-7 text-slate-300">
+            Estimate the full planning cost of an oversize move: permits, escorts, fuel, tolls,
+            lodging, police escort, route survey, waiting time, and contingency. Use this for
+            budgeting, then confirm final costs with the issuing authorities and hired operators.
+          </p>
+        </div>
+      </section>
+
+      <main className="mx-auto grid max-w-6xl gap-6 px-4 py-8 lg:grid-cols-[1fr_390px]">
+        <section className="rounded-2xl border border-white/10 bg-[#111827] p-5">
+          <h2 className="text-lg font-black">Move Inputs</h2>
+          <div className="mt-5 grid gap-4 sm:grid-cols-2">
+            <NumberField label="Route miles" value={state.miles} min={1} max={5000} onChange={setNumber('miles')} />
+            <NumberField label="Travel days" value={state.travelDays} min={1} max={30} onChange={setNumber('travelDays')} />
+            <NumberField label="Jurisdictions / permits" value={state.jurisdictions} min={1} max={25} onChange={setNumber('jurisdictions')} />
+            <NumberField label="Average permit cost" value={state.permitAverage} min={0} max={5000} onChange={setNumber('permitAverage')} />
+            <NumberField label="Escort vehicles" value={state.escortCount} min={0} max={8} onChange={setNumber('escortCount')} />
+            <NumberField label="Wait / detention hours" value={state.waitHours} min={0} max={96} onChange={setNumber('waitHours')} />
+            <NumberField label="Truck fuel MPG" value={state.fuelMpg} min={2} max={12} step={0.1} onChange={setNumber('fuelMpg')} />
+            <NumberField label="Diesel price / gallon" value={state.dieselPrice} min={1} max={12} step={0.01} onChange={setNumber('dieselPrice')} />
+            <NumberField label="Tolls / access fees" value={state.tolls} min={0} max={10000} onChange={setNumber('tolls')} />
+            <NumberField label="Overnight nights" value={state.overnightNights} min={0} max={30} onChange={setNumber('overnightNights')} />
+            <NumberField label="Overnight rate" value={state.overnightRate} min={0} max={500} onChange={setNumber('overnightRate')} />
+            <NumberField label="Police escort hours" value={state.policeHours} min={0} max={96} onChange={setNumber('policeHours')} />
+            <label className="block">
+              <span className="text-xs font-bold uppercase tracking-wider text-slate-400">Region</span>
+              <select
+                value={state.region}
+                onChange={(event) => setState((current) => ({ ...current, region: event.target.value as TripCostRegion }))}
+                className="mt-2 w-full rounded-xl border border-white/10 bg-[#0B0F14] px-3 py-3 text-white outline-none focus:border-[#F1A91B]"
+              >
+                {regions.map(([value, label]) => <option key={value} value={value}>{label}</option>)}
+              </select>
+            </label>
+            <label className="block">
+              <span className="text-xs font-bold uppercase tracking-wider text-slate-400">Move complexity</span>
+              <select
+                value={state.complexity}
+                onChange={(event) => setState((current) => ({ ...current, complexity: event.target.value as TripComplexity }))}
+                className="mt-2 w-full rounded-xl border border-white/10 bg-[#0B0F14] px-3 py-3 text-white outline-none focus:border-[#F1A91B]"
+              >
+                {complexities.map(([value, label]) => <option key={value} value={value}>{label}</option>)}
+              </select>
+            </label>
+          </div>
+
+          <div className="mt-5 grid gap-3 sm:grid-cols-2">
+            <label className="flex items-center gap-3 rounded-xl border border-white/10 bg-[#0B0F14] p-4">
+              <input
+                type="checkbox"
+                checked={state.highPole}
+                onChange={(event) => setState((current) => ({ ...current, highPole: event.target.checked }))}
+                className="h-5 w-5 accent-[#F1A91B]"
+              />
+              <span>
+                <span className="block text-sm font-bold">Include high-pole car</span>
+                <span className="text-xs text-slate-400">Use for overheight risk or permit language.</span>
+              </span>
+            </label>
+            <label className="flex items-center gap-3 rounded-xl border border-white/10 bg-[#0B0F14] p-4">
+              <input
+                type="checkbox"
+                checked={state.routeSurvey}
+                onChange={(event) => setState((current) => ({ ...current, routeSurvey: event.target.checked }))}
+                className="h-5 w-5 accent-[#F1A91B]"
+              />
+              <span>
+                <span className="block text-sm font-bold">Include route survey</span>
+                <span className="text-xs text-slate-400">Common for superloads and unfamiliar corridors.</span>
+              </span>
+            </label>
+          </div>
+        </section>
+
+        <aside className="space-y-4">
+          <div className="rounded-2xl border border-[#F1A91B]/20 bg-[#111827] p-5">
+            <h2 className="text-lg font-black">Estimated Cost Range</h2>
+            <div className="mt-4 grid gap-3">
+              <div className="rounded-xl bg-[#0B0F14] p-4">
+                <div className="text-xs text-slate-500">Planning midpoint</div>
+                <div className="text-4xl font-black text-[#F1A91B]">{money(result.midEstimate)}</div>
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div className="rounded-xl bg-[#0B0F14] p-4">
+                  <div className="text-xs text-slate-500">Low</div>
+                  <div className="text-2xl font-black">{money(result.lowEstimate)}</div>
+                </div>
+                <div className="rounded-xl bg-[#0B0F14] p-4">
+                  <div className="text-xs text-slate-500">High</div>
+                  <div className="text-2xl font-black">{money(result.highEstimate)}</div>
+                </div>
+              </div>
+              <div className="rounded-xl border border-white/10 bg-[#0B0F14] p-4 text-sm text-slate-300">
+                <div><strong>{result.travelDays}</strong> travel days</div>
+                <div><strong>{money(result.perMileMid)}</strong> midpoint cost per mile</div>
+              </div>
+            </div>
+          </div>
+
+          <div className="rounded-2xl border border-white/10 bg-[#111827] p-5">
+            <h2 className="text-lg font-black">Cost Breakdown</h2>
+            <div className="mt-4 space-y-3">
+              {costRows.map(([label, value]) => (
+                <div key={label} className="flex items-center justify-between border-b border-white/5 pb-2 text-sm">
+                  <span className="text-slate-400">{label}</span>
+                  <span className="font-bold">{money(value as number)}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {result.warnings.length > 0 && (
+            <div className="rounded-2xl border border-amber-400/20 bg-amber-400/10 p-5">
+              <h2 className="text-sm font-black uppercase tracking-wider text-amber-200">Planning Flags</h2>
+              <ul className="mt-3 space-y-2 text-sm leading-6 text-amber-100">
+                {result.warnings.map((warning) => <li key={warning}>{warning}</li>)}
+              </ul>
+            </div>
+          )}
+
+          <div className="rounded-2xl border border-[#F1A91B]/20 bg-[#111827] p-5">
+            <h2 className="text-lg font-black">Next Actions</h2>
+            <div className="mt-4 grid gap-3">
+              <Link href="/quote" className="rounded-xl bg-[#F1A91B] px-4 py-3 text-center text-sm font-black text-black">
+                Request a move quote
+              </Link>
+              <Link href="/directory?category=pilot-car" className="rounded-xl border border-white/10 px-4 py-3 text-center text-sm font-bold text-white hover:border-[#F1A91B]">
+                Find pilot car operators
+              </Link>
+              <Link href="/tools/pilot-car-rate-calculator" className="rounded-xl border border-white/10 px-4 py-3 text-center text-sm font-bold text-white hover:border-[#F1A91B]">
+                Check pilot car rates
+              </Link>
+            </div>
+          </div>
+        </aside>
+      </main>
+    </div>
+  );
+}

--- a/app/(public)/tools/total-trip-cost-calculator/page.tsx
+++ b/app/(public)/tools/total-trip-cost-calculator/page.tsx
@@ -1,156 +1,50 @@
 import type { Metadata } from 'next';
-import Link from 'next/link';
 import { createClient } from '@/lib/supabase/server';
+import { TotalTripCostCalculatorClient } from './TotalTripCostCalculatorClient';
+import type { TripCostBenchmarks } from '@/lib/tools/totalTripCost';
 
 export const metadata: Metadata = {
-  title: 'Total Trip Cost Calculator — Oversize Load Move Budget | Haul Command',
-  description: 'Estimate the complete cost of an oversize load move: permits, pilot cars, fuel, tolls, overnight stops, and detention time. Free planning ranges. Market coverage varies.',
+  title: 'Total Trip Cost Calculator - Oversize Load Move Budget | Haul Command',
+  description:
+    'Estimate the complete cost of an oversize load move: permits, pilot cars, fuel, tolls, overnight stops, waiting time, police escort, route survey, and contingency.',
   alternates: { canonical: 'https://www.haulcommand.com/tools/total-trip-cost-calculator' },
 };
 
 export const dynamic = 'force-dynamic';
 
+type RateRow = {
+  surface_key: string;
+  rate_mid: number | null;
+};
+
+function benchmarkValue(rows: RateRow[], key: string, fallback: number) {
+  const row = rows.find((item) => item.surface_key === key);
+  return typeof row?.rate_mid === 'number' && Number.isFinite(row.rate_mid) ? row.rate_mid : fallback;
+}
+
 export default async function TotalTripCostPage() {
   const supabase = createClient();
-  
-  // Pull rate benchmarks for the calculator context when the source table is available.
+
   const { data: rates } = await supabase
     .from('hc_rates_public')
-    .select('surface_key, jurisdiction_slug, rate_low, rate_mid, rate_high, currency_code')
-    .in('surface_key', ['us_pilot_car_daily', 'us_height_pole_rate', 'us_police_escort_rate', 'us_route_survey_rate', 'us_wait_time_rate'])
+    .select('surface_key, rate_mid')
+    .in('surface_key', [
+      'us_pilot_car_daily',
+      'us_height_pole_rate',
+      'us_police_escort_rate',
+      'us_route_survey_rate',
+      'us_wait_time_rate',
+    ])
     .limit(10);
 
-  const rateMap = (rates ?? []).reduce((acc: Record<string, any>, r) => { acc[r.surface_key] = r; return acc; }, {});
-  
-  const escortRate = rateMap['us_pilot_car_daily'] ?? { rate_low: 300, rate_mid: 450, rate_high: 650 };
-  const heightPoleRate = rateMap['us_height_pole_rate'] ?? { rate_low: 450, rate_mid: 600, rate_high: 850 };
-  const policeRate = rateMap['us_police_escort_rate'] ?? { rate_low: 85, rate_mid: 150, rate_high: 350 };
+  const rateRows = (rates ?? []) as RateRow[];
+  const benchmarks: TripCostBenchmarks = {
+    pilotCarDaily: benchmarkValue(rateRows, 'us_pilot_car_daily', 450),
+    heightPoleDaily: benchmarkValue(rateRows, 'us_height_pole_rate', 625),
+    policeHourly: benchmarkValue(rateRows, 'us_police_escort_rate', 150),
+    waitHourly: benchmarkValue(rateRows, 'us_wait_time_rate', 85),
+    routeSurveyFlat: benchmarkValue(rateRows, 'us_route_survey_rate', 900),
+  };
 
-  return (
-    <div className="min-h-screen bg-[#0B0F14] text-white">
-      <div className="border-b border-[#F1A91B]/10" style={{ background: 'linear-gradient(135deg, #0B0F14 0%, #0f1a24 100%)' }}>
-        <div className="max-w-4xl mx-auto px-4 py-12">
-          <div className="flex items-center gap-2 text-xs text-[#F1A91B] font-bold uppercase tracking-widest mb-4">
-            <Link href="/tools" className="hover:text-white">Tools</Link>
-            <span>›</span><span>Cost Intelligence</span>
-          </div>
-          <h1 className="text-4xl font-black mb-3">Total Trip Cost Calculator</h1>
-          <p className="text-gray-400 text-lg max-w-xl">Budget the full cost of an oversize load move — permits, escorts, fuel, tolls, overnight stops — using real market rate benchmarks from our network.</p>
-          <div className="flex flex-wrap gap-4 mt-4 text-xs text-gray-500">
-            <span className="flex items-center gap-1.5"><span className="w-1.5 h-1.5 rounded-full bg-green-400" />Planning rate data</span>
-            <span className="flex items-center gap-1.5"><span className="w-1.5 h-1.5 rounded-full bg-blue-400" />Market coverage varies</span>
-            <span className="flex items-center gap-1.5"><span className="w-1.5 h-1.5 rounded-full bg-[#F1A91B]" />No sign-up required</span>
-          </div>
-        </div>
-      </div>
-
-      <div className="max-w-4xl mx-auto px-4 py-10">
-        {/* Rate benchmarks from DB, with visible planning fallback ranges. */}
-        <div className="bg-[#111827] border border-white/[0.08] rounded-2xl p-6 mb-6">
-          <div className="flex items-center justify-between mb-4">
-            <h2 className="font-black text-xl">US Market Planning Benchmarks</h2>
-            <Link href="/rates" className="text-xs text-[#C6923A] hover:underline font-semibold">Full rate index →</Link>
-          </div>
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            {[
-              { label: 'Pilot Car / Day', low: escortRate.rate_low, mid: escortRate.rate_mid, high: escortRate.rate_high, unit: 'USD/day' },
-              { label: 'Height Pole / Day', low: heightPoleRate.rate_low, mid: heightPoleRate.rate_mid, high: heightPoleRate.rate_high, unit: 'USD/day' },
-              { label: 'Police Escort', low: policeRate.rate_low, mid: policeRate.rate_mid, high: policeRate.rate_high, unit: 'USD/hr' },
-            ].map(r => (
-              <div key={r.label} className="p-4 bg-[#0d1117] rounded-xl border border-white/[0.04]">
-                <div className="text-xs text-gray-500 font-semibold uppercase tracking-wider mb-2">{r.label}</div>
-                <div className="flex items-end gap-2">
-                  <span className="text-2xl font-black text-white">${r.mid}</span>
-                  <span className="text-xs text-gray-500 mb-0.5">{r.unit}</span>
-                </div>
-                <div className="text-xs text-gray-600 mt-1">Range: ${r.low} – ${r.high}</div>
-              </div>
-            ))}
-          </div>
-        </div>
-
-        {/* Cost components breakdown */}
-        <div className="bg-[#111827] border border-white/[0.08] rounded-2xl p-6 mb-6">
-          <h2 className="font-black text-xl mb-5">Trip Cost Components</h2>
-          <div className="space-y-3">
-            {[
-              { component: 'State Permits', typical: '$150–$800 per state', notes: 'Average $300/state for standard OW moves. Superloads can exceed $2,500/state.' },
-              { component: 'Pilot Cars (lead + chase)', typical: '$600–$1,400/day', notes: 'Based on 2 escorts at $300–$700/day each. Multi-day moves are more expensive per day.' },
-              { component: 'Height Pole Car', typical: '$450–$850/day', notes: 'Required when load exceeds 14.5 ft. Counts toward escort requirement.' },
-              { component: 'Fuel Surcharge', typical: '15–20% of escort rate', notes: 'Applied per mile over 150 miles from operator home base.' },
-              { component: 'Overnight / Per Diem', typical: '$75–$150/operator/night', notes: 'Hotel + meal allowance for multi-day moves. Usually 1.5–2 nights per 800 miles.' },
-              { component: 'Police Escort', typical: '$85–$350/hour', notes: 'Required in certain jurisdictions and for extreme loads (> 16 ft wide).' },
-              { component: 'Route Survey', typical: '$500–$1,200', notes: 'Required for superloads and new corridor routes. Usually a one-time fee per move.' },
-            ].map(c => (
-              <div key={c.component} className="grid grid-cols-1 sm:grid-cols-3 gap-2 p-4 bg-[#0d1117] rounded-xl border border-white/[0.04] items-start">
-                <div className="font-bold text-white text-sm">{c.component}</div>
-                <div className="text-sm font-bold text-[#F1A91B]">{c.typical}</div>
-                <div className="text-xs text-gray-500 leading-relaxed">{c.notes}</div>
-              </div>
-            ))}
-          </div>
-        </div>
-
-        {/* Example calculation */}
-        <div className="bg-[#111827] border border-[#F1A91B]/20 rounded-2xl p-6 mb-8">
-          <h2 className="font-black text-xl mb-2">Example: 1,200-Mile Industrial Equipment Move</h2>
-          <p className="text-sm text-gray-400 mb-5">14 ft wide × 85 ft long — crossing TX, LA, MS, AL (4 states, 3 days)</p>
-          <div className="space-y-2">
-            {[
-              { item: 'State permits (4 states × $350 avg)', cost: '$1,400' },
-              { item: '2 pilot cars × 3 days × $450/day', cost: '$2,700' },
-              { item: 'Fuel surcharges (15% of escort)', cost: '$405' },
-              { item: 'Overnight per diem (2 nights × 2 operators)', cost: '$500' },
-              { item: 'Height pole car (1 day in TX)', cost: '$600' },
-            ].map(l => (
-              <div key={l.item} className="flex justify-between text-sm py-1.5 border-b border-white/[0.04]">
-                <span className="text-gray-400">{l.item}</span>
-                <span className="font-bold text-white">{l.cost}</span>
-              </div>
-            ))}
-            <div className="flex justify-between text-base pt-2 font-black">
-              <span className="text-white">Total estimated move cost</span>
-              <span className="text-[#F1A91B]">$5,605</span>
-            </div>
-          </div>
-        </div>
-
-        {/* Directory CTA */}
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-8">
-          <Link href="/directory" className="flex items-center justify-between p-5 bg-[#111827] hover:bg-[#F1A91B]/5 border border-[#F1A91B]/20 rounded-2xl transition-all group">
-            <div>
-              <div className="font-black text-white">Find Escort Operators</div>
-              <div className="text-xs text-gray-400 mt-1">Browse operator records by market</div>
-            </div>
-            <span className="text-[#F1A91B] group-hover:translate-x-1 transition-transform">→</span>
-          </Link>
-          <Link href="/tools/pilot-car-rate-calculator" className="flex items-center justify-between p-5 bg-[#111827] hover:bg-[#F1A91B]/5 border border-white/[0.08] rounded-2xl transition-all group">
-            <div>
-              <div className="font-black text-white">Rate Benchmark Tool</div>
-              <div className="text-xs text-gray-400 mt-1">Compare rates by state and corridor</div>
-            </div>
-            <span className="text-[#F1A91B] group-hover:translate-x-1 transition-transform">→</span>
-          </Link>
-        </div>
-
-        {/* Interlinking grid */}
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-          {[
-            { href: '/tools/escort-count-calculator', label: 'Escort Count', icon: '🚗' },
-            { href: '/tools/permit-cost-calculator', label: 'Permit Costs', icon: '📋' },
-            { href: '/tools/deadhead-cost-calculator', label: 'Deadhead Cost', icon: '↩️' },
-            { href: '/rates', label: 'Rate Index', icon: '💰' },
-            { href: '/corridors', label: 'Corridors', icon: '🛣️' },
-            { href: '/available-now', label: 'Available Now', icon: '📡' },
-            { href: '/glossary', label: 'Glossary', icon: '📖' },
-            { href: '/training', label: 'Get Certified', icon: '🎓' },
-          ].map(l => (
-            <Link key={l.href} href={l.href} className="flex items-center gap-2 p-3 bg-[#111827] hover:bg-[#F1A91B]/5 border border-white/[0.06] hover:border-[#F1A91B]/20 rounded-xl text-xs font-semibold text-gray-400 hover:text-[#F1A91B] transition-all">
-              <span>{l.icon}</span>{l.label}
-            </Link>
-          ))}
-        </div>
-      </div>
-    </div>
-  );
+  return <TotalTripCostCalculatorClient benchmarks={benchmarks} />;
 }

--- a/lib/tools/totalTripCost.ts
+++ b/lib/tools/totalTripCost.ts
@@ -1,0 +1,178 @@
+export type TripCostRegion =
+  | 'southeast'
+  | 'texas_gulf'
+  | 'midwest'
+  | 'mountain_west'
+  | 'west_coast'
+  | 'northeast'
+  | 'canada';
+
+export type TripComplexity = 'standard' | 'overwide' | 'overheight' | 'superload' | 'emergency';
+
+export type TripCostBenchmarks = {
+  pilotCarDaily: number;
+  heightPoleDaily: number;
+  policeHourly: number;
+  waitHourly: number;
+  routeSurveyFlat: number;
+};
+
+export type TotalTripCostInput = {
+  miles: number;
+  jurisdictions: number;
+  travelDays: number;
+  escortCount: number;
+  permitAverage: number;
+  fuelMpg: number;
+  dieselPrice: number;
+  tolls: number;
+  overnightNights: number;
+  overnightRate: number;
+  waitHours: number;
+  policeHours: number;
+  routeSurvey: boolean;
+  highPole: boolean;
+  region: TripCostRegion;
+  complexity: TripComplexity;
+  benchmarks?: Partial<TripCostBenchmarks>;
+};
+
+export type TotalTripCostResult = {
+  miles: number;
+  travelDays: number;
+  permitCost: number;
+  escortCost: number;
+  highPoleCost: number;
+  fuelCost: number;
+  tollCost: number;
+  overnightCost: number;
+  waitCost: number;
+  policeCost: number;
+  routeSurveyCost: number;
+  contingency: number;
+  lowEstimate: number;
+  midEstimate: number;
+  highEstimate: number;
+  perMileMid: number;
+  warnings: string[];
+};
+
+export const totalTripRegionLabels: Record<TripCostRegion, string> = {
+  southeast: 'Southeast',
+  texas_gulf: 'Texas / Gulf Coast',
+  midwest: 'Midwest',
+  mountain_west: 'Mountain West',
+  west_coast: 'West Coast',
+  northeast: 'Northeast',
+  canada: 'Canada',
+};
+
+export const totalTripComplexityLabels: Record<TripComplexity, string> = {
+  standard: 'Standard oversize',
+  overwide: 'Overwide',
+  overheight: 'Overheight',
+  superload: 'Superload',
+  emergency: 'Emergency / short notice',
+};
+
+const REGION_ESCORT_FACTOR: Record<TripCostRegion, number> = {
+  southeast: 0.94,
+  texas_gulf: 1.02,
+  midwest: 1,
+  mountain_west: 1.12,
+  west_coast: 1.22,
+  northeast: 1.28,
+  canada: 1.3,
+};
+
+const COMPLEXITY_FACTOR: Record<TripComplexity, number> = {
+  standard: 1,
+  overwide: 1.1,
+  overheight: 1.16,
+  superload: 1.38,
+  emergency: 1.55,
+};
+
+const DEFAULT_BENCHMARKS: TripCostBenchmarks = {
+  pilotCarDaily: 450,
+  heightPoleDaily: 625,
+  policeHourly: 150,
+  waitHourly: 85,
+  routeSurveyFlat: 900,
+};
+
+function clampNumber(value: number, min: number, max: number) {
+  if (!Number.isFinite(value)) return min;
+  return Math.min(max, Math.max(min, value));
+}
+
+function dollars(value: number) {
+  return Math.round(value);
+}
+
+export function calculateTotalTripCost(input: TotalTripCostInput): TotalTripCostResult {
+  const miles = clampNumber(input.miles, 1, 5000);
+  const jurisdictions = clampNumber(input.jurisdictions, 1, 25);
+  const travelDays = clampNumber(input.travelDays, 1, 30);
+  const escortCount = clampNumber(input.escortCount, 0, 8);
+  const permitAverage = clampNumber(input.permitAverage, 0, 5000);
+  const fuelMpg = clampNumber(input.fuelMpg, 2, 12);
+  const dieselPrice = clampNumber(input.dieselPrice, 1, 12);
+  const tolls = clampNumber(input.tolls, 0, 10000);
+  const overnightNights = clampNumber(input.overnightNights, 0, 30);
+  const overnightRate = clampNumber(input.overnightRate, 0, 500);
+  const waitHours = clampNumber(input.waitHours, 0, 96);
+  const policeHours = clampNumber(input.policeHours, 0, 96);
+  const region = input.region in REGION_ESCORT_FACTOR ? input.region : 'midwest';
+  const complexity = input.complexity in COMPLEXITY_FACTOR ? input.complexity : 'standard';
+  const benchmarks = { ...DEFAULT_BENCHMARKS, ...(input.benchmarks ?? {}) };
+  const factor = REGION_ESCORT_FACTOR[region] * COMPLEXITY_FACTOR[complexity];
+
+  const permitCost = jurisdictions * permitAverage * (complexity === 'superload' ? 1.35 : 1);
+  const escortCost = escortCount * travelDays * benchmarks.pilotCarDaily * factor;
+  const highPoleCost = input.highPole ? travelDays * benchmarks.heightPoleDaily * factor : 0;
+  const fuelCost = (miles / fuelMpg) * dieselPrice;
+  const overnightCost = overnightNights * overnightRate * Math.max(1, escortCount);
+  const waitCost = waitHours * benchmarks.waitHourly * Math.max(1, escortCount);
+  const policeCost = policeHours * benchmarks.policeHourly;
+  const routeSurveyCost = input.routeSurvey ? benchmarks.routeSurveyFlat * (complexity === 'superload' ? 1.25 : 1) : 0;
+
+  const subtotal =
+    permitCost +
+    escortCost +
+    highPoleCost +
+    fuelCost +
+    tolls +
+    overnightCost +
+    waitCost +
+    policeCost +
+    routeSurveyCost;
+  const contingency = subtotal * (complexity === 'emergency' ? 0.18 : complexity === 'superload' ? 0.15 : 0.1);
+  const midEstimate = subtotal + contingency;
+  const warnings: string[] = [];
+
+  if (escortCount === 0) warnings.push('No escort cost included. Confirm the route does not require pilot cars.');
+  if (jurisdictions > 6) warnings.push('Many jurisdictions increase permit lead-time and denial risk.');
+  if (input.highPole && !input.routeSurvey) warnings.push('High-pole work often pairs with a route survey on overheight moves.');
+  if (complexity === 'superload') warnings.push('Superload pricing should be confirmed with authority-specific permit and routing requirements.');
+
+  return {
+    miles,
+    travelDays,
+    permitCost: dollars(permitCost),
+    escortCost: dollars(escortCost),
+    highPoleCost: dollars(highPoleCost),
+    fuelCost: dollars(fuelCost),
+    tollCost: dollars(tolls),
+    overnightCost: dollars(overnightCost),
+    waitCost: dollars(waitCost),
+    policeCost: dollars(policeCost),
+    routeSurveyCost: dollars(routeSurveyCost),
+    contingency: dollars(contingency),
+    lowEstimate: dollars(midEstimate * 0.86),
+    midEstimate: dollars(midEstimate),
+    highEstimate: dollars(midEstimate * 1.22),
+    perMileMid: dollars(midEstimate / miles),
+    warnings,
+  };
+}

--- a/tests/unit/total-trip-cost-calculator.test.ts
+++ b/tests/unit/total-trip-cost-calculator.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { calculateTotalTripCost } from '@/lib/tools/totalTripCost';
+
+describe('calculateTotalTripCost', () => {
+  it('calculates a complete oversize move budget with core cost components', () => {
+    const result = calculateTotalTripCost({
+      miles: 1200,
+      jurisdictions: 4,
+      travelDays: 3,
+      escortCount: 2,
+      permitAverage: 350,
+      fuelMpg: 5.5,
+      dieselPrice: 4.25,
+      tolls: 250,
+      overnightNights: 2,
+      overnightRate: 140,
+      waitHours: 4,
+      policeHours: 0,
+      routeSurvey: false,
+      highPole: true,
+      region: 'texas_gulf',
+      complexity: 'overheight',
+    });
+
+    expect(result.permitCost).toBe(1400);
+    expect(result.escortCost).toBeGreaterThan(0);
+    expect(result.highPoleCost).toBeGreaterThan(0);
+    expect(result.fuelCost).toBeGreaterThan(900);
+    expect(result.midEstimate).toBeGreaterThan(result.lowEstimate);
+    expect(result.highEstimate).toBeGreaterThan(result.midEstimate);
+  });
+
+  it('clamps unsafe inputs and surfaces planning warnings', () => {
+    const result = calculateTotalTripCost({
+      miles: -1,
+      jurisdictions: 99,
+      travelDays: 99,
+      escortCount: 0,
+      permitAverage: 99999,
+      fuelMpg: 0,
+      dieselPrice: 99,
+      tolls: 99999,
+      overnightNights: 99,
+      overnightRate: 999,
+      waitHours: 999,
+      policeHours: 999,
+      routeSurvey: false,
+      highPole: true,
+      region: 'northeast',
+      complexity: 'superload',
+    });
+
+    expect(result.miles).toBe(1);
+    expect(result.travelDays).toBe(30);
+    expect(result.permitCost).toBe(25 * 5000 * 1.35);
+    expect(result.tollCost).toBe(10000);
+    expect(result.warnings).toContain('No escort cost included. Confirm the route does not require pilot cars.');
+    expect(result.warnings).toContain('Many jurisdictions increase permit lead-time and denial risk.');
+  });
+});


### PR DESCRIPTION
## Summary
- replace the static total trip cost page with an interactive calculator UI
- add a reusable `calculateTotalTripCost` engine covering permits, escorts, high-pole, fuel, tolls, lodging, waiting time, police escort, route survey, and contingency
- keep Supabase-backed rate benchmark inputs when available, with transparent planning fallbacks
- add focused unit coverage for normal and clamped edge-case inputs

## Verification
- `npm test -- tests/unit/total-trip-cost-calculator.test.ts`
- `npm run typecheck`
- `npm run build`

## Notes
No DB schema changes. Existing build warnings are unrelated Supabase/static-generation warnings already present in this worktree.