### PR TITLE
Build escort count calculator engine

### DIFF
--- a/app/(public)/tools/escort-count-calculator/EscortCountCalculatorClient.tsx
+++ b/app/(public)/tools/escort-count-calculator/EscortCountCalculatorClient.tsx
@@ -1,0 +1,287 @@
+'use client';
+
+import Link from 'next/link';
+import type { ChangeEvent } from 'react';
+import { useMemo, useState } from 'react';
+import {
+  calculateEscortCount,
+  escortRoadContextLabels,
+  OVERSIZE_LIMITS,
+  type EscortRoadContext,
+} from '@/lib/tools/escortCount';
+import type { OversizeJurisdictionCode } from '@/lib/tools/oversizeLoad';
+
+const PRESETS = [
+  { label: '12 ft wide excavator', widthFeet: 12, heightFeet: 13.8, lengthFeet: 68, grossWeightLbs: 90000 },
+  { label: 'Tall transformer', widthFeet: 11, heightFeet: 15.2, lengthFeet: 78, grossWeightLbs: 148000 },
+  { label: 'Long blade section', widthFeet: 10.5, heightFeet: 13.9, lengthFeet: 128, grossWeightLbs: 76000 },
+  { label: 'Superload screen', widthFeet: 17, heightFeet: 16, lengthFeet: 150, grossWeightLbs: 240000 },
+];
+
+const MATRIX = [
+  { trigger: 'One-escort width threshold', action: 'Plan one pilot car, then verify position with permit conditions.' },
+  { trigger: 'Two-escort width threshold', action: 'Plan front and rear escorts before quoting.' },
+  { trigger: 'High-pole height threshold', action: 'Plan a high-pole car and vertical-clearance review.' },
+  { trigger: '100+ ft length', action: 'Expect rear-control review; 120+ ft often needs front and rear planning.' },
+  { trigger: 'Superload-like size or weight', action: 'Plan route survey, agency review, and possible police escort.' },
+];
+
+function formatNumber(value: number) {
+  return new Intl.NumberFormat('en-US').format(value);
+}
+
+function numberFieldValue(value: number, setter: (value: number) => void) {
+  return {
+    value,
+    onChange: (event: ChangeEvent<HTMLInputElement>) => setter(Number(event.target.value)),
+  };
+}
+
+export function EscortCountCalculatorClient() {
+  const [jurisdiction, setJurisdiction] = useState<OversizeJurisdictionCode>('US');
+  const [roadContext, setRoadContext] = useState<EscortRoadContext>('interstate');
+  const [widthFeet, setWidthFeet] = useState(12);
+  const [heightFeet, setHeightFeet] = useState(14);
+  const [lengthFeet, setLengthFeet] = useState(80);
+  const [grossWeightLbs, setGrossWeightLbs] = useState(90000);
+  const [hazmat, setHazmat] = useState(false);
+
+  const result = useMemo(
+    () =>
+      calculateEscortCount({
+        jurisdiction,
+        roadContext,
+        widthFeet,
+        heightFeet,
+        lengthFeet,
+        grossWeightLbs,
+        hazmat,
+      }),
+    [grossWeightLbs, hazmat, heightFeet, jurisdiction, lengthFeet, roadContext, widthFeet],
+  );
+
+  const statusColor =
+    result.planningStatus === 'no_escort_flagged'
+      ? '#22c55e'
+      : result.planningStatus === 'escort_likely'
+        ? '#F1A91B'
+        : '#ef4444';
+
+  return (
+    <main data-hc-topic-hero="manual" className="min-h-screen bg-[#0B0F14] text-white">
+      <section className="border-b border-[#F1A91B]/10 bg-[#071019]">
+        <div className="mx-auto max-w-6xl px-4 py-12">
+          <div className="mb-4 flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-[#F1A91B]">
+            <Link href="/tools" className="hover:text-white">
+              Tools
+            </Link>
+            <span>/</span>
+            <span>Escort Intelligence</span>
+          </div>
+          <h1 className="mb-3 text-4xl font-black">Escort Count Calculator</h1>
+          <p className="max-w-2xl text-lg leading-relaxed text-gray-400">
+            Estimate lead, chase, high-pole, police, and route-survey needs from load dimensions and route context before quoting a move.
+          </p>
+        </div>
+      </section>
+
+      <section className="mx-auto grid max-w-6xl gap-6 px-4 py-10 lg:grid-cols-[420px_1fr]">
+        <div className="space-y-5">
+          <div className="rounded-2xl border border-white/[0.08] bg-[#111827] p-6">
+            <h2 className="mb-5 text-sm font-black uppercase tracking-wider">Move Inputs</h2>
+            <div className="space-y-4">
+              <label className="block">
+                <span className="mb-1.5 block text-xs font-bold uppercase tracking-wider text-gray-500">Planning jurisdiction</span>
+                <select
+                  value={jurisdiction}
+                  onChange={(event) => setJurisdiction(event.target.value as OversizeJurisdictionCode)}
+                  className="w-full rounded-xl border border-white/10 bg-[#0B0F14] px-3 py-3 text-sm text-white outline-none focus:border-[#F1A91B]"
+                >
+                  {OVERSIZE_LIMITS.map((profile) => (
+                    <option key={profile.code} value={profile.code}>
+                      {profile.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <label className="block">
+                <span className="mb-1.5 block text-xs font-bold uppercase tracking-wider text-gray-500">Route context</span>
+                <select
+                  value={roadContext}
+                  onChange={(event) => setRoadContext(event.target.value as EscortRoadContext)}
+                  className="w-full rounded-xl border border-white/10 bg-[#0B0F14] px-3 py-3 text-sm text-white outline-none focus:border-[#F1A91B]"
+                >
+                  {Object.entries(escortRoadContextLabels).map(([value, label]) => (
+                    <option key={value} value={value}>
+                      {label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              {[
+                { label: 'Width (ft)', min: 1, step: 0.1, props: numberFieldValue(widthFeet, setWidthFeet) },
+                { label: 'Height (ft)', min: 1, step: 0.1, props: numberFieldValue(heightFeet, setHeightFeet) },
+                { label: 'Overall length (ft)', min: 1, step: 1, props: numberFieldValue(lengthFeet, setLengthFeet) },
+                { label: 'Gross weight (lb)', min: 1, step: 1000, props: numberFieldValue(grossWeightLbs, setGrossWeightLbs) },
+              ].map((field) => (
+                <label key={field.label} className="block">
+                  <span className="mb-1.5 block text-xs font-bold uppercase tracking-wider text-gray-500">{field.label}</span>
+                  <input
+                    type="number"
+                    min={field.min}
+                    step={field.step}
+                    {...field.props}
+                    className="w-full rounded-xl border border-white/10 bg-[#0B0F14] px-3 py-3 text-sm text-white outline-none focus:border-[#F1A91B]"
+                  />
+                </label>
+              ))}
+
+              <label className="flex items-center gap-3 rounded-xl border border-white/[0.08] bg-[#0B0F14] p-3 text-sm font-bold text-gray-300">
+                <input
+                  type="checkbox"
+                  checked={hazmat}
+                  onChange={(event) => setHazmat(event.target.checked)}
+                  className="h-4 w-4 accent-[#F1A91B]"
+                />
+                Hazmat or emergency-response coordination involved
+              </label>
+            </div>
+          </div>
+
+          <div className="rounded-2xl border border-white/[0.08] bg-[#111827] p-6">
+            <h2 className="mb-4 text-sm font-black uppercase tracking-wider">Common presets</h2>
+            <div className="grid gap-2">
+              {PRESETS.map((preset) => (
+                <button
+                  key={preset.label}
+                  type="button"
+                  onClick={() => {
+                    setWidthFeet(preset.widthFeet);
+                    setHeightFeet(preset.heightFeet);
+                    setLengthFeet(preset.lengthFeet);
+                    setGrossWeightLbs(preset.grossWeightLbs);
+                  }}
+                  className="rounded-xl border border-white/[0.08] bg-[#0B0F14] px-3 py-3 text-left text-sm text-gray-300 hover:border-[#F1A91B]/40 hover:text-white"
+                >
+                  <span className="block font-bold text-white">{preset.label}</span>
+                  {preset.widthFeet} ft W / {preset.heightFeet} ft H / {preset.lengthFeet} ft L / {formatNumber(preset.grossWeightLbs)} lb
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="space-y-6">
+          <div className="rounded-2xl border border-white/[0.08] bg-[#111827] p-6">
+            <div className="mb-6 flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+              <div>
+                <p className="mb-2 text-xs font-bold uppercase tracking-widest text-gray-500">Result</p>
+                <h2 className="text-3xl font-black" style={{ color: statusColor }}>
+                  {result.statusLabel}
+                </h2>
+                <p className="mt-3 max-w-2xl text-sm leading-relaxed text-gray-400">
+                  Planning profile: {result.jurisdictionLabel}. This screen estimates dispatch posture; final authority comes from the issued permit and route-specific conditions.
+                </p>
+              </div>
+              <div className="rounded-xl border border-white/10 bg-[#0B0F14] px-5 py-4 text-right">
+                <p className="text-xs uppercase tracking-wider text-gray-500">Escort vehicles</p>
+                <p className="text-3xl font-black text-white">{result.totalEscortVehicles}</p>
+              </div>
+            </div>
+
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+              {[
+                ['Lead', result.leadEscorts],
+                ['Chase', result.chaseEscorts],
+                ['High-pole', result.highPoleCars],
+                ['Police', result.policeEscortsLikely ? 'Likely' : 'Not flagged'],
+                ['Survey', result.routeSurveyLikely ? 'Likely' : 'Not flagged'],
+              ].map(([label, value]) => (
+                <div key={label} className="rounded-xl border border-white/[0.06] bg-[#0B0F14] p-4">
+                  <p className="text-[11px] font-bold uppercase tracking-wider text-gray-500">{label}</p>
+                  <p className="mt-1 text-lg font-black text-white">{value}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="grid gap-6 lg:grid-cols-2">
+            <div className="rounded-2xl border border-white/[0.08] bg-[#111827] p-6">
+              <h2 className="mb-4 text-sm font-black uppercase tracking-wider">Triggered Rules</h2>
+              <div className="space-y-3 text-sm leading-relaxed text-gray-300">
+                {result.triggers.map((trigger) => (
+                  <div key={trigger} className="rounded-xl border border-white/[0.06] bg-[#0B0F14] p-3">
+                    {trigger}
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded-2xl border border-[#F1A91B]/20 bg-[#F1A91B]/5 p-6">
+              <h2 className="mb-4 text-sm font-black uppercase tracking-wider text-[#F1A91B]">Next Actions</h2>
+              <ol className="space-y-3 text-sm leading-relaxed text-gray-300">
+                {result.nextActions.map((action) => (
+                  <li key={action} className="rounded-xl border border-[#F1A91B]/10 bg-[#0B0F14] p-3">
+                    {action}
+                  </li>
+                ))}
+              </ol>
+            </div>
+          </div>
+
+          {result.cautions.length > 0 && (
+            <div className="rounded-2xl border border-orange-500/20 bg-orange-500/5 p-6">
+              <h2 className="mb-4 text-sm font-black uppercase tracking-wider text-orange-300">Cautions</h2>
+              <ul className="space-y-2 text-sm text-orange-100/80">
+                {result.cautions.map((caution) => (
+                  <li key={caution}>{caution}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          <div className="rounded-2xl border border-white/[0.08] bg-[#111827] p-6">
+            <h2 className="mb-4 text-sm font-black uppercase tracking-wider">Planning Matrix</h2>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead className="text-left text-xs uppercase tracking-wider text-gray-500">
+                  <tr>
+                    <th className="pb-3">Trigger</th>
+                    <th className="pb-3">Dispatch action</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-white/[0.06]">
+                  {MATRIX.map((row) => (
+                    <tr key={row.trigger}>
+                      <td className="py-3 pr-4 font-bold text-[#F1A91B]">{row.trigger}</td>
+                      <td className="py-3 text-gray-400">{row.action}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            {[
+              ['/tools/pilot-car-rate-calculator', 'Price Escorts'],
+              ['/tools/total-trip-cost-calculator', 'Total Trip Cost'],
+              ['/tools/oversize-load-checker', 'Oversize Check'],
+              ['/directory', 'Find Operators'],
+            ].map(([href, label]) => (
+              <Link
+                key={href}
+                href={href}
+                className="rounded-xl border border-white/[0.08] bg-[#111827] px-4 py-3 text-center text-sm font-bold text-gray-300 hover:border-[#F1A91B]/40 hover:text-[#F1A91B]"
+              >
+                {label}
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app/(public)/tools/escort-count-calculator/EscortCountCalculatorClient.tsx
+++ b/app/(public)/tools/escort-count-calculator/EscortCountCalculatorClient.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import Link from 'next/link';
-import type { ChangeEvent } from 'react';
 import { useMemo, useState } from 'react';
 import {
   calculateEscortCount,
@@ -26,24 +25,41 @@ const MATRIX = [
   { trigger: 'Superload-like size or weight', action: 'Plan route survey, agency review, and possible police escort.' },
 ];
 
+const FAQ_ITEMS = [
+  {
+    question: 'How many pilot cars does an oversize load need?',
+    answer:
+      'Pilot car count depends on width, height, length, route context, and permit conditions. A common planning pattern is one escort near the first width threshold, front and rear escorts at higher widths, high-pole support for tall loads, and police or traffic control for superload-like moves.',
+  },
+  {
+    question: 'Does a high-pole car count as an escort vehicle?',
+    answer:
+      'A high-pole car is usually an escort vehicle assigned to vertical clearance screening. Whether it counts as the required lead escort depends on the permit and jurisdiction.',
+  },
+  {
+    question: 'Can this replace the issued permit?',
+    answer:
+      'No. This calculator is a planning screen. The issued permit, route survey, and agency instructions control the final escort and traffic-control requirements.',
+  },
+];
+
 function formatNumber(value: number) {
   return new Intl.NumberFormat('en-US').format(value);
 }
 
-function numberFieldValue(value: number, setter: (value: number) => void) {
-  return {
-    value,
-    onChange: (event: ChangeEvent<HTMLInputElement>) => setter(Number(event.target.value)),
-  };
+function parseInput(value: string, fallback: number) {
+  if (value.trim() === '') return fallback;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
 }
 
 export function EscortCountCalculatorClient() {
   const [jurisdiction, setJurisdiction] = useState<OversizeJurisdictionCode>('US');
   const [roadContext, setRoadContext] = useState<EscortRoadContext>('interstate');
-  const [widthFeet, setWidthFeet] = useState(12);
-  const [heightFeet, setHeightFeet] = useState(14);
-  const [lengthFeet, setLengthFeet] = useState(80);
-  const [grossWeightLbs, setGrossWeightLbs] = useState(90000);
+  const [widthFeet, setWidthFeet] = useState('12');
+  const [heightFeet, setHeightFeet] = useState('14');
+  const [lengthFeet, setLengthFeet] = useState('80');
+  const [grossWeightLbs, setGrossWeightLbs] = useState('90000');
   const [hazmat, setHazmat] = useState(false);
 
   const result = useMemo(
@@ -51,10 +67,10 @@ export function EscortCountCalculatorClient() {
       calculateEscortCount({
         jurisdiction,
         roadContext,
-        widthFeet,
-        heightFeet,
-        lengthFeet,
-        grossWeightLbs,
+        widthFeet: parseInput(widthFeet, 1),
+        heightFeet: parseInput(heightFeet, 1),
+        lengthFeet: parseInput(lengthFeet, 1),
+        grossWeightLbs: parseInput(grossWeightLbs, 1),
         hazmat,
       }),
     [grossWeightLbs, hazmat, heightFeet, jurisdiction, lengthFeet, roadContext, widthFeet],
@@ -121,10 +137,10 @@ export function EscortCountCalculatorClient() {
               </label>
 
               {[
-                { label: 'Width (ft)', min: 1, step: 0.1, props: numberFieldValue(widthFeet, setWidthFeet) },
-                { label: 'Height (ft)', min: 1, step: 0.1, props: numberFieldValue(heightFeet, setHeightFeet) },
-                { label: 'Overall length (ft)', min: 1, step: 1, props: numberFieldValue(lengthFeet, setLengthFeet) },
-                { label: 'Gross weight (lb)', min: 1, step: 1000, props: numberFieldValue(grossWeightLbs, setGrossWeightLbs) },
+                { label: 'Width (ft)', value: widthFeet, set: setWidthFeet, min: 1, step: 0.1 },
+                { label: 'Height (ft)', value: heightFeet, set: setHeightFeet, min: 1, step: 0.1 },
+                { label: 'Overall length (ft)', value: lengthFeet, set: setLengthFeet, min: 1, step: 1 },
+                { label: 'Gross weight (lb)', value: grossWeightLbs, set: setGrossWeightLbs, min: 1, step: 1000 },
               ].map((field) => (
                 <label key={field.label} className="block">
                   <span className="mb-1.5 block text-xs font-bold uppercase tracking-wider text-gray-500">{field.label}</span>
@@ -132,7 +148,8 @@ export function EscortCountCalculatorClient() {
                     type="number"
                     min={field.min}
                     step={field.step}
-                    {...field.props}
+                    value={field.value}
+                    onChange={(event) => field.set(event.target.value)}
                     className="w-full rounded-xl border border-white/10 bg-[#0B0F14] px-3 py-3 text-sm text-white outline-none focus:border-[#F1A91B]"
                   />
                 </label>
@@ -158,10 +175,10 @@ export function EscortCountCalculatorClient() {
                   key={preset.label}
                   type="button"
                   onClick={() => {
-                    setWidthFeet(preset.widthFeet);
-                    setHeightFeet(preset.heightFeet);
-                    setLengthFeet(preset.lengthFeet);
-                    setGrossWeightLbs(preset.grossWeightLbs);
+                    setWidthFeet(String(preset.widthFeet));
+                    setHeightFeet(String(preset.heightFeet));
+                    setLengthFeet(String(preset.lengthFeet));
+                    setGrossWeightLbs(String(preset.grossWeightLbs));
                   }}
                   className="rounded-xl border border-white/[0.08] bg-[#0B0F14] px-3 py-3 text-left text-sm text-gray-300 hover:border-[#F1A91B]/40 hover:text-white"
                 >
@@ -261,6 +278,18 @@ export function EscortCountCalculatorClient() {
                   ))}
                 </tbody>
               </table>
+            </div>
+          </div>
+
+          <div className="rounded-2xl border border-white/[0.08] bg-[#111827] p-6">
+            <h2 className="mb-4 text-sm font-black uppercase tracking-wider">Escort Count FAQs</h2>
+            <div className="space-y-3">
+              {FAQ_ITEMS.map((item) => (
+                <details key={item.question} className="rounded-xl border border-white/[0.06] bg-[#0B0F14] p-4">
+                  <summary className="cursor-pointer text-sm font-bold text-white">{item.question}</summary>
+                  <p className="mt-3 text-sm leading-relaxed text-gray-400">{item.answer}</p>
+                </details>
+              ))}
             </div>
           </div>
 

--- a/app/(public)/tools/escort-count-calculator/page.tsx
+++ b/app/(public)/tools/escort-count-calculator/page.tsx
@@ -1,96 +1,63 @@
 import type { Metadata } from 'next';
-import Link from 'next/link';
+import { JsonLd } from '@/components/seo/JsonLd';
+import { EscortCountCalculatorClient } from './EscortCountCalculatorClient';
 
 export const metadata: Metadata = {
-  title: 'Escort Count Calculator — How Many Pilot Cars? | Haul Command',
-  description: 'Calculate exactly how many pilot cars your oversize load legally requires. Based on width, height, length, and state-by-state requirements.',
+  title: 'Escort Count Calculator - Pilot Car Planning | Haul Command',
+  description:
+    'Estimate lead, chase, high-pole, police escort, and route survey needs from load dimensions and route context before quoting an oversize move.',
   alternates: { canonical: 'https://www.haulcommand.com/tools/escort-count-calculator' },
 };
 
-const RULES = [
-  { condition: 'Up to 12 ft wide', lead: 0, chase: 0, note: 'Most states: no escort required under 12 ft' },
-  { condition: '12–14 ft wide', lead: 1, chase: 0, note: 'Lead car required. Some states require rear too.' },
-  { condition: '14–16 ft wide', lead: 1, chase: 1, note: 'Lead + chase required in nearly all states' },
-  { condition: 'Over 16 ft wide', lead: 1, chase: 1, note: 'Lead + chase + possible police escort required' },
-  { condition: 'Height > 16 ft', lead: 1, chase: 0, note: 'Height pole car required (counts as lead)' },
-  { condition: 'Length > 100 ft', lead: 1, chase: 1, note: 'Front and rear escorts required in most states' },
-];
+const toolSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'WebApplication',
+  name: 'Escort Count Calculator',
+  url: 'https://www.haulcommand.com/tools/escort-count-calculator',
+  description:
+    'Pilot car escort count planning tool for oversize and heavy-haul moves. Estimates lead, chase, high-pole, police, and route survey needs.',
+  applicationCategory: 'BusinessApplication',
+  isAccessibleForFree: true,
+  offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+};
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: [
+    {
+      '@type': 'Question',
+      name: 'How many pilot cars does an oversize load need?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'Pilot car count depends on width, height, length, route context, and permit conditions. A common planning pattern is one escort near the first width threshold, front and rear escorts at higher widths, high-pole support for tall loads, and police or traffic control for superload-like moves.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'Does a high-pole car count as an escort vehicle?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'A high-pole car is usually an escort vehicle assigned to vertical clearance screening. Whether it counts as the required lead escort depends on the permit and jurisdiction.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'Can this replace the issued permit?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'No. This calculator is a planning screen. The issued permit, route survey, and agency instructions control the final escort and traffic-control requirements.',
+      },
+    },
+  ],
+};
 
 export default function EscortCountCalculatorPage() {
   return (
-    <div className="min-h-screen bg-[#0B0F14] text-white">
-      <div className="border-b border-[#F1A91B]/10" style={{ background: 'linear-gradient(135deg, #0B0F14 0%, #0f1a24 100%)' }}>
-        <div className="max-w-4xl mx-auto px-4 py-12">
-          <div className="flex items-center gap-2 text-xs text-[#F1A91B] font-bold uppercase tracking-widest mb-4">
-            <Link href="/tools" className="hover:text-white transition-colors">Tools</Link>
-            <span>›</span><span>Escort Intelligence</span>
-          </div>
-          <h1 className="text-4xl font-black mb-3">Escort Count Calculator</h1>
-          <p className="text-gray-400 text-lg max-w-xl">How many pilot cars does your load legally require? Reference guide for all standard US configurations by width, height, and length.</p>
-        </div>
-      </div>
-
-      <div className="max-w-4xl mx-auto px-4 py-10">
-        {/* Escort requirement matrix */}
-        <div className="bg-[#111827] border border-white/[0.08] rounded-2xl p-6 mb-6">
-          <h2 className="font-black text-xl mb-5">Standard Escort Requirements by Dimension</h2>
-          <div className="space-y-3">
-            {RULES.map(r => (
-              <div key={r.condition} className="grid grid-cols-1 sm:grid-cols-4 gap-3 p-4 bg-[#0d1117] rounded-xl border border-white/[0.04] items-center">
-                <div className="font-bold text-[#F1A91B] text-sm">{r.condition}</div>
-                <div className="flex items-center gap-2">
-                  <span className={`w-6 h-6 rounded-full flex items-center justify-center text-xs font-black ${r.lead > 0 ? 'bg-[#F1A91B] text-black' : 'bg-white/10 text-gray-500'}`}>{r.lead}</span>
-                  <span className="text-xs text-gray-500">Lead</span>
-                </div>
-                <div className="flex items-center gap-2">
-                  <span className={`w-6 h-6 rounded-full flex items-center justify-center text-xs font-black ${r.chase > 0 ? 'bg-[#F1A91B] text-black' : 'bg-white/10 text-gray-500'}`}>{r.chase}</span>
-                  <span className="text-xs text-gray-500">Chase</span>
-                </div>
-                <div className="text-xs text-gray-500 leading-relaxed">{r.note}</div>
-              </div>
-            ))}
-          </div>
-        </div>
-
-        {/* Special cases */}
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-5 mb-8">
-          <div className="bg-[#111827] border border-white/[0.08] rounded-2xl p-5">
-            <h3 className="font-black mb-3 text-[#F1A91B]">Height Pole Cars</h3>
-            <p className="text-sm text-gray-400 leading-relaxed">Required when load exceeds 14.5 ft in most states. The height pole car travels ahead testing bridge and utility clearances. Counts as the lead escort.</p>
-            <Link href="/tools/oversize-load-checker" className="inline-block mt-3 text-xs font-bold text-[#C6923A] hover:underline">Check height requirements →</Link>
-          </div>
-          <div className="bg-[#111827] border border-white/[0.08] rounded-2xl p-5">
-            <h3 className="font-black mb-3 text-[#F1A91B]">Police Escorts</h3>
-            <p className="text-sm text-gray-400 leading-relaxed">Typically required above 16 ft wide or through metro areas. Some states (TX, LA) require police for extreme loads above 18 ft. Billed per hour, not per day.</p>
-            <Link href="/escort-requirements" className="inline-block mt-3 text-xs font-bold text-[#C6923A] hover:underline">State requirements →</Link>
-          </div>
-        </div>
-
-        {/* Cost estimator CTA */}
-        <div className="bg-gradient-to-r from-[#0B0F14] to-[#0f1a24] border border-[#F1A91B]/20 rounded-2xl p-6 flex flex-col sm:flex-row items-center justify-between gap-4">
-          <div>
-            <div className="font-black text-lg">Know Your Escort Count?</div>
-            <p className="text-sm text-gray-400 mt-1">Calculate the full trip cost including escorts, permits, and fuel.</p>
-          </div>
-          <Link href="/tools/total-trip-cost-calculator" className="shrink-0 px-5 py-2.5 bg-[#F1A91B] hover:bg-[#D4951A] text-black font-bold rounded-xl text-sm transition-colors">
-            Total Trip Cost →
-          </Link>
-        </div>
-
-        {/* Interlinking */}
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mt-6">
-          {[
-            { href: '/tools/oversize-load-checker', label: 'Oversize Checker', icon: '📏' },
-            { href: '/tools/permit-cost-calculator', label: 'Permit Costs', icon: '📋' },
-            { href: '/directory', label: 'Find Escorts', icon: '🔍' },
-            { href: '/training', label: 'Get Certified', icon: '🎓' },
-          ].map(l => (
-            <Link key={l.href} href={l.href} className="flex items-center gap-2 p-3 bg-[#111827] hover:bg-[#F1A91B]/5 border border-white/[0.06] hover:border-[#F1A91B]/20 rounded-xl text-xs font-semibold text-gray-400 hover:text-[#F1A91B] transition-all">
-              <span>{l.icon}</span>{l.label}
-            </Link>
-          ))}
-        </div>
-      </div>
-    </div>
+    <>
+      <JsonLd data={toolSchema} />
+      <JsonLd data={faqSchema} />
+      <EscortCountCalculatorClient />
+    </>
   );
 }

--- a/lib/tools/escortCount.ts
+++ b/lib/tools/escortCount.ts
@@ -1,0 +1,164 @@
+import {
+  getOversizeLimitProfile,
+  OVERSIZE_LIMITS,
+  type OversizeJurisdictionCode,
+} from '@/lib/tools/oversizeLoad';
+
+export type EscortRoadContext = 'interstate' | 'two_lane' | 'metro' | 'restricted' | 'cross_border';
+
+export type EscortCountInput = {
+  jurisdiction: OversizeJurisdictionCode;
+  widthFeet: number;
+  heightFeet: number;
+  lengthFeet: number;
+  grossWeightLbs: number;
+  roadContext: EscortRoadContext;
+  hazmat: boolean;
+};
+
+export type EscortCountResult = {
+  jurisdictionLabel: string;
+  leadEscorts: number;
+  chaseEscorts: number;
+  highPoleCars: number;
+  policeEscortsLikely: boolean;
+  routeSurveyLikely: boolean;
+  totalEscortVehicles: number;
+  planningStatus: 'no_escort_flagged' | 'escort_likely' | 'complex_move_review';
+  statusLabel: string;
+  triggers: string[];
+  cautions: string[];
+  nextActions: string[];
+};
+
+export const escortRoadContextLabels: Record<EscortRoadContext, string> = {
+  interstate: 'Interstate / divided highway',
+  two_lane: 'Two-lane or rural route',
+  metro: 'Metro / urban restriction zone',
+  restricted: 'Known restricted route',
+  cross_border: 'Cross-border or multi-agency move',
+};
+
+function clamp(value: number, min: number, max: number) {
+  if (!Number.isFinite(value)) return min;
+  return Math.min(max, Math.max(min, value));
+}
+
+export function calculateEscortCount(input: EscortCountInput): EscortCountResult {
+  const profile = getOversizeLimitProfile(input.jurisdiction);
+  const widthFeet = clamp(input.widthFeet, 1, 30);
+  const heightFeet = clamp(input.heightFeet, 1, 25);
+  const lengthFeet = clamp(input.lengthFeet, 1, 250);
+  const grossWeightLbs = clamp(input.grossWeightLbs, 1, 1_000_000);
+
+  const triggers: string[] = [];
+  const cautions: string[] = [];
+
+  let leadEscorts = 0;
+  let chaseEscorts = 0;
+  let highPoleCars = 0;
+
+  if (widthFeet >= profile.escortWidthTwoFeet) {
+    leadEscorts = 1;
+    chaseEscorts = 1;
+    triggers.push(`Width is at or above the two-escort planning threshold for ${profile.label}.`);
+  } else if (widthFeet >= profile.escortWidthOneFeet) {
+    leadEscorts = 1;
+    triggers.push(`Width is at or above the one-escort planning threshold for ${profile.label}.`);
+  }
+
+  if (heightFeet >= profile.highPoleHeightFeet) {
+    highPoleCars = 1;
+    leadEscorts = Math.max(leadEscorts, 1);
+    triggers.push(`Height meets the high-pole planning threshold for ${profile.label}.`);
+  } else if (heightFeet >= profile.highPoleHeightFeet - 0.5) {
+    cautions.push('Height is close to the high-pole threshold. Confirm route clearance before quoting.');
+  }
+
+  if (lengthFeet >= 120) {
+    leadEscorts = Math.max(leadEscorts, 1);
+    chaseEscorts = Math.max(chaseEscorts, 1);
+    triggers.push('Overall length is 120 ft or longer, which commonly triggers front and rear escort review.');
+  } else if (lengthFeet >= 100) {
+    chaseEscorts = Math.max(chaseEscorts, 1);
+    triggers.push('Overall length is 100 ft or longer, which commonly triggers rear escort review.');
+  }
+
+  if (input.roadContext === 'two_lane' || input.roadContext === 'restricted') {
+    if (widthFeet >= profile.escortWidthOneFeet || lengthFeet >= 90) {
+      chaseEscorts = Math.max(chaseEscorts, 1);
+      triggers.push(`${escortRoadContextLabels[input.roadContext]} increases rear-control risk.`);
+    }
+  }
+
+  const superloadLike =
+    widthFeet >= profile.superloadWidthFeet || grossWeightLbs >= profile.superloadWeightLbs || lengthFeet >= 150;
+  const policeEscortsLikely =
+    superloadLike ||
+    (input.roadContext === 'metro' && (widthFeet >= profile.escortWidthTwoFeet || heightFeet >= profile.highPoleHeightFeet)) ||
+    (input.roadContext === 'restricted' && widthFeet >= profile.superloadWidthFeet - 1);
+  const routeSurveyLikely =
+    superloadLike ||
+    heightFeet >= profile.highPoleHeightFeet ||
+    lengthFeet >= 120 ||
+    input.roadContext === 'restricted' ||
+    input.roadContext === 'cross_border';
+
+  if (policeEscortsLikely) {
+    triggers.push('Police or traffic-control coordination is likely based on size, weight, or route context.');
+  }
+  if (routeSurveyLikely) {
+    triggers.push('Route survey or agency route review should be planned before dispatch.');
+  }
+  if (input.hazmat) {
+    cautions.push('Hazmat moves may require separate escort, routing, or emergency-response coordination.');
+  }
+  if (input.roadContext === 'cross_border') {
+    cautions.push('Cross-border moves need each jurisdiction checked separately; this is only a planning screen.');
+  }
+
+  const totalEscortVehicles = Math.max(leadEscorts + chaseEscorts, highPoleCars);
+  const planningStatus =
+    policeEscortsLikely || routeSurveyLikely
+      ? 'complex_move_review'
+      : totalEscortVehicles > 0
+        ? 'escort_likely'
+        : 'no_escort_flagged';
+  const statusLabel = {
+    no_escort_flagged: 'No escort flagged by this planning screen',
+    escort_likely: 'Pilot car escort likely',
+    complex_move_review: 'Complex escort review likely',
+  }[planningStatus];
+
+  const nextActions = [
+    totalEscortVehicles > 0
+      ? `Plan for at least ${totalEscortVehicles} escort vehicle${totalEscortVehicles === 1 ? '' : 's'} before pricing the move.`
+      : 'Still verify permit conditions because local routes can require escorts below common width thresholds.',
+    highPoleCars > 0
+      ? 'Assign a qualified high-pole operator and check vertical clearance before dispatch.'
+      : 'Run the oversize checker if height is close to bridge or utility clearance limits.',
+    policeEscortsLikely
+      ? 'Contact the permit office or law-enforcement coordinator before quoting final timing.'
+      : 'Use the pilot-car rate calculator to price the estimated escort count.',
+    routeSurveyLikely
+      ? 'Budget time for route survey, agency review, and possible curfew restrictions.'
+      : 'Check total trip cost after permit and escort count are known.',
+  ];
+
+  return {
+    jurisdictionLabel: profile.label,
+    leadEscorts,
+    chaseEscorts,
+    highPoleCars,
+    policeEscortsLikely,
+    routeSurveyLikely,
+    totalEscortVehicles,
+    planningStatus,
+    statusLabel,
+    triggers: triggers.length ? triggers : ['No escort trigger was detected from the entered planning dimensions.'],
+    cautions,
+    nextActions,
+  };
+}
+
+export { OVERSIZE_LIMITS };

--- a/tests/unit/escort-count-calculator.test.ts
+++ b/tests/unit/escort-count-calculator.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { calculateEscortCount } from '@/lib/tools/escortCount';
+
+describe('calculateEscortCount', () => {
+  it('estimates a standard wide move with one lead escort', () => {
+    const result = calculateEscortCount({
+      jurisdiction: 'US',
+      widthFeet: 12,
+      heightFeet: 13.8,
+      lengthFeet: 70,
+      grossWeightLbs: 90000,
+      roadContext: 'interstate',
+      hazmat: false,
+    });
+
+    expect(result.leadEscorts).toBe(1);
+    expect(result.chaseEscorts).toBe(0);
+    expect(result.highPoleCars).toBe(0);
+    expect(result.totalEscortVehicles).toBe(1);
+    expect(result.planningStatus).toBe('escort_likely');
+  });
+
+  it('flags high-pole, route survey, and police review for a complex move', () => {
+    const result = calculateEscortCount({
+      jurisdiction: 'TX',
+      widthFeet: 17,
+      heightFeet: 17.2,
+      lengthFeet: 150,
+      grossWeightLbs: 260000,
+      roadContext: 'restricted',
+      hazmat: true,
+    });
+
+    expect(result.leadEscorts).toBe(1);
+    expect(result.chaseEscorts).toBe(1);
+    expect(result.highPoleCars).toBe(1);
+    expect(result.totalEscortVehicles).toBe(2);
+    expect(result.policeEscortsLikely).toBe(true);
+    expect(result.routeSurveyLikely).toBe(true);
+    expect(result.planningStatus).toBe('complex_move_review');
+    expect(result.cautions).toContain('Hazmat moves may require separate escort, routing, or emergency-response coordination.');
+  });
+
+  it('clamps unusable numeric inputs before scoring', () => {
+    const result = calculateEscortCount({
+      jurisdiction: 'CA',
+      widthFeet: -4,
+      heightFeet: -1,
+      lengthFeet: -10,
+      grossWeightLbs: -200,
+      roadContext: 'interstate',
+      hazmat: false,
+    });
+
+    expect(result.totalEscortVehicles).toBe(0);
+    expect(result.planningStatus).toBe('no_escort_flagged');
+  });
+});


### PR DESCRIPTION
## Summary
- Replaces the static escort count page with a real interactive planning calculator.
- Adds a reusable escort-count rules engine for lead, chase, high-pole, police, and route-survey estimates.
- Adds WebApplication and FAQ JSON-LD plus targeted unit coverage.

## Verification
- `npm test -- tests/unit/escort-count-calculator.test.ts`
- `npm run typecheck`
- `npm run build`
- `npm run lint`

## Notes
- This remains a planning screen, not a substitute for issued permits or official route conditions.