### PR TITLE
Build certification timeline estimator

### DIFF
--- a/app/(public)/tools/certification-timeline/CertificationTimelineClient.tsx
+++ b/app/(public)/tools/certification-timeline/CertificationTimelineClient.tsx
@@ -1,0 +1,404 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useMemo, useState } from 'react';
+import {
+  calculateCertificationTimeline,
+  certificationPaceLabels,
+  isCertificationStudyPace,
+  type CertificationPath,
+  type CertificationStudyPace,
+} from '@/lib/tools/certificationTimeline';
+
+const paceOptions = Object.entries(certificationPaceLabels) as [CertificationStudyPace, string][];
+
+function formatCurrency(value: number) {
+  if (value <= 0) return 'Verify';
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(new Date(`${value}T12:00:00.000Z`));
+}
+
+function localDateInputValue(date: Date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function uniquePaths(paths: CertificationPath[]) {
+  const seen = new Set<string>();
+  return paths.filter((path) => {
+    if (!path.jurisdiction_code || seen.has(path.jurisdiction_code)) return false;
+    seen.add(path.jurisdiction_code);
+    return true;
+  });
+}
+
+export function CertificationTimelineClient({
+  paths,
+}: {
+  paths: CertificationPath[];
+}) {
+  const options = useMemo(() => uniquePaths(paths), [paths]);
+  const defaultTarget =
+    options.find((path) => path.requires_certification)?.jurisdiction_code ??
+    options[0]?.jurisdiction_code ??
+    'manual';
+  const [targetCode, setTargetCode] = useState(defaultTarget);
+  const [currentCredentialCode, setCurrentCredentialCode] = useState('none');
+  const [pace, setPace] = useState<CertificationStudyPace>('part_time');
+  const [startDate, setStartDate] = useState('');
+  const [manualJurisdiction, setManualJurisdiction] = useState('Manual jurisdiction');
+  const [manualRequiresCertification, setManualRequiresCertification] = useState(true);
+  const [manualTrainingHours, setManualTrainingHours] = useState('16');
+  const [manualCertificationCost, setManualCertificationCost] = useState('300');
+  const [manualRenewalYears, setManualRenewalYears] = useState('3');
+
+  const effectiveOptions = useMemo<CertificationPath[]>(() => {
+    if (options.length > 0) return options;
+    return [
+      {
+        id: 'manual',
+        jurisdiction_code: 'manual',
+        jurisdiction_name: manualJurisdiction.trim() || 'Manual jurisdiction',
+        requires_certification: manualRequiresCertification,
+        training_hours: Number(manualTrainingHours) || 0,
+        certification_cost: Number(manualCertificationCost) || 0,
+        renewal_period_years: Number(manualRenewalYears) || null,
+        reciprocity_states: [],
+      },
+    ];
+  }, [
+    manualCertificationCost,
+    manualJurisdiction,
+    manualRenewalYears,
+    manualRequiresCertification,
+    manualTrainingHours,
+    options,
+  ]);
+
+  const result = useMemo(() => {
+    return calculateCertificationTimeline(effectiveOptions, {
+      targetCode: targetCode || effectiveOptions[0].jurisdiction_code,
+      currentCredentialCode,
+      pace,
+      startDate,
+    });
+  }, [currentCredentialCode, effectiveOptions, pace, startDate, targetCode]);
+
+  useEffect(() => {
+    setStartDate((current) => current || localDateInputValue(new Date()));
+  }, []);
+
+  const isManualMode = options.length === 0;
+  const requiringCert = effectiveOptions.filter((path) => path.requires_certification).length;
+  const noCertMarked = effectiveOptions.length - requiringCert;
+  const reciprocalNames =
+    result.target.reciprocity_states
+      ?.map((code) => effectiveOptions.find((path) => path.jurisdiction_code === code)?.jurisdiction_name ?? code)
+      .slice(0, 8) ?? [];
+
+  return (
+    <div data-hc-topic-hero="manual" className="min-h-screen bg-[#0B0F14] text-white">
+      <section className="border-b border-[#F1A91B]/10">
+        <div className="mx-auto max-w-6xl px-4 py-12">
+          <div className="mb-4 flex items-center gap-2 text-xs font-bold uppercase tracking-[0.2em] text-[#F1A91B]">
+            <Link href="/tools" className="hover:text-white">
+              Tools
+            </Link>
+            <span>/</span>
+            <span>Certification</span>
+          </div>
+          <h1 className="max-w-4xl text-3xl font-black tracking-tight md:text-5xl">
+            Pilot Car Certification Timeline
+          </h1>
+          <p className="mt-4 max-w-3xl text-base leading-7 text-slate-300">
+            Estimate when an operator can be ready for a target jurisdiction using stored training
+            hours, fee records, renewal cycles, and reciprocity indicators. This is a planning tool;
+            the official issuing authority controls final eligibility.
+          </p>
+          <div className="mt-6 grid gap-3 sm:grid-cols-3">
+            <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+              <div className="text-2xl font-black text-[#F1A91B]">{options.length}</div>
+              <div className="text-xs font-bold uppercase tracking-wider text-slate-400">Stored jurisdictions loaded</div>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+              <div className="text-2xl font-black text-[#F1A91B]">{requiringCert}</div>
+              <div className="text-xs font-bold uppercase tracking-wider text-slate-400">Marked certification-required</div>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+              <div className="text-2xl font-black text-[#F1A91B]">{noCertMarked}</div>
+              <div className="text-xs font-bold uppercase tracking-wider text-slate-400">Marked no-certification</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <main className="mx-auto grid max-w-6xl gap-6 px-4 py-8 lg:grid-cols-[1fr_380px]">
+        <section className="rounded-2xl border border-white/10 bg-[#111827] p-5">
+          <h2 className="text-lg font-black">Timeline Inputs</h2>
+          {isManualMode && (
+            <div className="mt-4 rounded-xl border border-amber-400/20 bg-amber-400/10 p-4 text-sm leading-6 text-amber-100">
+              Stored certification path records did not load in this environment. Manual planning
+              mode is active, so the estimate uses the values you enter below instead of inventing
+              jurisdiction-specific rules.
+            </div>
+          )}
+          <div className="mt-5 grid gap-4 sm:grid-cols-2">
+            <label className="block">
+              <span className="text-xs font-bold uppercase tracking-wider text-slate-400">Target jurisdiction</span>
+              {isManualMode ? (
+                <input
+                  type="text"
+                  value={manualJurisdiction}
+                  onChange={(event) => setManualJurisdiction(event.target.value)}
+                  className="mt-2 w-full rounded-xl border border-white/10 bg-[#0B0F14] px-3 py-3 text-white outline-none focus:border-[#F1A91B]"
+                />
+              ) : (
+                <select
+                  value={result.target.jurisdiction_code}
+                  onChange={(event) => setTargetCode(event.target.value)}
+                  className="mt-2 w-full rounded-xl border border-white/10 bg-[#0B0F14] px-3 py-3 text-white outline-none focus:border-[#F1A91B]"
+                >
+                  {effectiveOptions.map((path) => (
+                    <option key={path.jurisdiction_code} value={path.jurisdiction_code}>
+                      {path.jurisdiction_name}
+                    </option>
+                  ))}
+                </select>
+              )}
+            </label>
+
+            <label className="block">
+              <span className="text-xs font-bold uppercase tracking-wider text-slate-400">Current credential</span>
+              <select
+                value={currentCredentialCode}
+                onChange={(event) => setCurrentCredentialCode(event.target.value)}
+                disabled={isManualMode}
+                className="mt-2 w-full rounded-xl border border-white/10 bg-[#0B0F14] px-3 py-3 text-white outline-none focus:border-[#F1A91B]"
+              >
+                <option value="none">No active credential</option>
+                {effectiveOptions.map((path) => (
+                  <option key={path.jurisdiction_code} value={path.jurisdiction_code}>
+                    {path.jurisdiction_name}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="block">
+              <span className="text-xs font-bold uppercase tracking-wider text-slate-400">Study pace</span>
+              <select
+                value={pace}
+                onChange={(event) => {
+                  const next = event.target.value;
+                  if (isCertificationStudyPace(next)) setPace(next);
+                }}
+                className="mt-2 w-full rounded-xl border border-white/10 bg-[#0B0F14] px-3 py-3 text-white outline-none focus:border-[#F1A91B]"
+              >
+                {paceOptions.map(([value, label]) => (
+                  <option key={value} value={value}>
+                    {label}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="block">
+              <span className="text-xs font-bold uppercase tracking-wider text-slate-400">Start date</span>
+              <input
+                type="date"
+                value={startDate}
+                onChange={(event) => setStartDate(event.target.value)}
+                className="mt-2 w-full rounded-xl border border-white/10 bg-[#0B0F14] px-3 py-3 text-white outline-none focus:border-[#F1A91B]"
+              />
+            </label>
+          </div>
+
+          {isManualMode && (
+            <div className="mt-4 grid gap-4 sm:grid-cols-2">
+              <label className="flex items-center gap-3 rounded-xl border border-white/10 bg-[#0B0F14] px-3 py-3">
+                <input
+                  type="checkbox"
+                  checked={manualRequiresCertification}
+                  onChange={(event) => setManualRequiresCertification(event.target.checked)}
+                  className="h-4 w-4"
+                />
+                <span className="text-sm font-bold">Certification required for this plan</span>
+              </label>
+              <label className="block">
+                <span className="text-xs font-bold uppercase tracking-wider text-slate-400">Training hours</span>
+                <input
+                  type="number"
+                  min={0}
+                  value={manualTrainingHours}
+                  onChange={(event) => setManualTrainingHours(event.target.value)}
+                  className="mt-2 w-full rounded-xl border border-white/10 bg-[#0B0F14] px-3 py-3 text-white outline-none focus:border-[#F1A91B]"
+                />
+              </label>
+              <label className="block">
+                <span className="text-xs font-bold uppercase tracking-wider text-slate-400">Certification fees</span>
+                <input
+                  type="number"
+                  min={0}
+                  value={manualCertificationCost}
+                  onChange={(event) => setManualCertificationCost(event.target.value)}
+                  className="mt-2 w-full rounded-xl border border-white/10 bg-[#0B0F14] px-3 py-3 text-white outline-none focus:border-[#F1A91B]"
+                />
+              </label>
+              <label className="block">
+                <span className="text-xs font-bold uppercase tracking-wider text-slate-400">Renewal cycle years</span>
+                <input
+                  type="number"
+                  min={0}
+                  value={manualRenewalYears}
+                  onChange={(event) => setManualRenewalYears(event.target.value)}
+                  className="mt-2 w-full rounded-xl border border-white/10 bg-[#0B0F14] px-3 py-3 text-white outline-none focus:border-[#F1A91B]"
+                />
+              </label>
+            </div>
+          )}
+
+          <div className="mt-6 rounded-2xl border border-[#F1A91B]/20 bg-[#F1A91B]/10 p-5">
+            <div className="text-xs font-bold uppercase tracking-[0.18em] text-[#F1A91B]">Ready date</div>
+            <div className="mt-2 text-4xl font-black">{formatDate(result.readyDate)}</div>
+            <p className="mt-2 text-sm leading-6 text-slate-300">
+              Estimated {result.estimatedDays} calendar day{result.estimatedDays === 1 ? '' : 's'} for{' '}
+              {result.target.jurisdiction_name}.{' '}
+              {result.reciprocityLikely
+                ? 'The selected credential appears to shorten the path through reciprocity.'
+                : 'No reciprocity shortcut is currently applied.'}
+            </p>
+          </div>
+
+          <div className="mt-6 grid gap-3 sm:grid-cols-4">
+            {[
+              ['Training hours', result.trainingHours === null ? 'Verify' : `${result.trainingHours}`],
+              ['Estimated fees', formatCurrency(result.estimatedCost)],
+              ['Renewal cycle', result.renewalPeriodYears ? `${result.renewalPeriodYears} yr` : 'Verify'],
+              ['Reciprocity', result.reciprocityLikely ? 'Likely' : 'Not applied'],
+            ].map(([label, value]) => (
+              <div key={label} className="rounded-xl border border-white/10 bg-[#0B0F14] p-4">
+                <div className="text-xs font-bold uppercase tracking-wider text-slate-500">{label}</div>
+                <div className="mt-2 text-xl font-black">{value}</div>
+              </div>
+            ))}
+          </div>
+
+          <section className="mt-7">
+            <h2 className="text-lg font-black">Certification Steps</h2>
+            <div className="mt-4 space-y-3">
+              {result.steps.map((step, index) => (
+                <div key={step.label} className="rounded-2xl border border-white/10 bg-[#0B0F14] p-4">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <div className="text-xs font-bold uppercase tracking-wider text-[#F1A91B]">Step {index + 1}</div>
+                      <h3 className="mt-1 text-base font-black">{step.label}</h3>
+                    </div>
+                    <div className="rounded-full bg-white/10 px-3 py-1 text-sm font-bold">{step.days} days</div>
+                  </div>
+                  <p className="mt-3 text-sm leading-6 text-slate-300">{step.detail}</p>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          {reciprocalNames.length > 0 && (
+            <section className="mt-7 rounded-2xl border border-white/10 bg-white/[0.03] p-5">
+              <h2 className="text-lg font-black">Reciprocity Signals</h2>
+              <p className="mt-2 text-sm leading-6 text-slate-300">
+                {result.target.jurisdiction_name} has reciprocity records for these credentials in
+                the current data. Confirm documentation requirements before relying on any
+                reciprocal badge.
+              </p>
+              <div className="mt-4 flex flex-wrap gap-2">
+                {reciprocalNames.map((name) => (
+                  <span key={name} className="rounded-full border border-white/10 bg-[#0B0F14] px-3 py-2 text-xs font-bold text-slate-200">
+                    {name}
+                  </span>
+                ))}
+              </div>
+            </section>
+          )}
+        </section>
+
+        <aside className="space-y-5">
+          <section className="rounded-2xl border border-white/10 bg-[#111827] p-5">
+            <h2 className="text-lg font-black">Warnings</h2>
+            <div className="mt-4 space-y-3">
+              {result.warnings.map((warning) => (
+                <p key={warning} className="rounded-xl border border-amber-400/20 bg-amber-400/10 p-3 text-sm leading-6 text-amber-100">
+                  {warning}
+                </p>
+              ))}
+            </div>
+          </section>
+
+          <section className="rounded-2xl border border-white/10 bg-[#111827] p-5">
+            <h2 className="text-lg font-black">Next Actions</h2>
+            <div className="mt-4 grid gap-3">
+              {[
+                ['/training', 'Find approved training'],
+                ['/tools/certification-reciprocity-checker', 'Check reciprocity'],
+                ['/claim', 'Add credentials to profile'],
+                ['/directory', 'Find certified operators'],
+              ].map(([href, label]) => (
+                <Link
+                  key={href}
+                  href={href}
+                  className="rounded-xl border border-white/10 bg-[#0B0F14] px-4 py-3 text-sm font-bold text-white hover:border-[#F1A91B]"
+                >
+                  {label}
+                </Link>
+              ))}
+            </div>
+          </section>
+        </aside>
+      </main>
+
+      <section className="mx-auto max-w-6xl px-4 pb-12">
+        <div className="rounded-2xl border border-white/10 bg-[#111827] p-5">
+          <h2 className="text-lg font-black">Jurisdiction Matrix</h2>
+          <div className="mt-4 overflow-x-auto">
+            <table className="w-full min-w-[720px] border-separate border-spacing-y-2 text-left text-sm">
+              <thead className="text-xs uppercase tracking-wider text-slate-500">
+                <tr>
+                  <th className="px-3 py-2">Jurisdiction</th>
+                  <th className="px-3 py-2">Certification</th>
+                  <th className="px-3 py-2">Hours</th>
+                  <th className="px-3 py-2">Stored fee</th>
+                  <th className="px-3 py-2">Renewal</th>
+                  <th className="px-3 py-2">Reciprocity records</th>
+                </tr>
+              </thead>
+              <tbody>
+                {effectiveOptions.map((path) => (
+                  <tr key={path.jurisdiction_code} className="bg-[#0B0F14]">
+                    <td className="rounded-l-xl px-3 py-3 font-bold">{path.jurisdiction_name}</td>
+                    <td className="px-3 py-3">{path.requires_certification ? 'Required' : 'Not marked required'}</td>
+                    <td className="px-3 py-3">{path.training_hours ?? 'Verify'}</td>
+                    <td className="px-3 py-3">{formatCurrency(path.certification_cost ?? 0)}</td>
+                    <td className="px-3 py-3">{path.renewal_period_years ? `${path.renewal_period_years} yr` : 'Verify'}</td>
+                    <td className="rounded-r-xl px-3 py-3">{path.reciprocity_states?.length ?? 0}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/(public)/tools/certification-timeline/page.tsx
+++ b/app/(public)/tools/certification-timeline/page.tsx
@@ -1,28 +1,17 @@
 import type { Metadata } from 'next';
 import { createClient } from '@/lib/supabase/server';
-import Link from 'next/link';
-import { Award, ShieldCheck, Map, ArrowRight, Zap, GraduationCap } from 'lucide-react';
 import { ProofStrip } from '@/components/ui/ProofStrip';
-import { NoDeadEndBlock } from '@/components/ui/NoDeadEndBlock';
+import { CertificationTimelineClient } from './CertificationTimelineClient';
+import type { CertificationPath } from '@/lib/tools/certificationTimeline';
 
 export const dynamic = 'force-dynamic';
 
 export const metadata: Metadata = {
-  title: 'State Certification Timelines & Reciprocity | Haul Command',
-  description: 'View pilot car certification requirements, reciprocity paths, and training timelines for all 50 states.',
-  alternates: { canonical: 'https://www.haulcommand.com/tools/certification-timeline' }
+  title: 'State Certification Timeline Estimator | Haul Command',
+  description:
+    'Estimate pilot car certification readiness dates using stored jurisdiction requirements, training hours, fees, renewal cycles, and reciprocity indicators.',
+  alternates: { canonical: 'https://www.haulcommand.com/tools/certification-timeline' },
 };
-
-interface CertPath {
-  id: string;
-  jurisdiction_code: string;
-  jurisdiction_name: string;
-  requires_certification: boolean;
-  training_hours: number;
-  certification_cost: number;
-  renewal_period_years: number;
-  reciprocity_states: string[];
-}
 
 export default async function CertificationTimelinePage() {
   const supabase = createClient();
@@ -31,96 +20,12 @@ export default async function CertificationTimelinePage() {
     .select('*')
     .order('jurisdiction_name', { ascending: true });
 
-  const activeRecords = (certs || []) as CertPath[];
+  const activeRecords = (certs || []) as CertificationPath[];
 
   return (
     <>
       <ProofStrip variant="bar" />
-      <div data-hc-topic-hero="manual" style={{ minHeight: '100vh', background: '#0a0914', color: '#e5e7eb', fontFamily: "'Inter', system-ui" }}>
-        
-        {/* -- HERO -- */}
-        <div style={{ position: 'relative', borderBottom: '1px solid rgba(255,255,255,0.05)', overflow: 'hidden' }}>
-          <div style={{ position: 'absolute', inset: 0, background: 'radial-gradient(ellipse 80% 50% at 50% -10%, rgba(245,158,11,0.08), transparent 70%)', pointerEvents: 'none' }} />
-          <div style={{ maxWidth: 1100, margin: '0 auto', padding: '3.5rem 1.5rem 3rem' }}>
-            <nav style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 11, color: '#4b5563', marginBottom: 20, textTransform: 'uppercase', letterSpacing: 1, fontWeight: 700 }}>
-              <Link href="/tools" style={{ color: '#6b7280', textDecoration: 'none' }}>Tools Hub</Link>
-              <span style={{ color: '#4b5563' }}>"º</span>
-              <span style={{ color: '#f59e0b' }}>Certifications</span>
-            </nav>
-            <h1 style={{ margin: '0 0 12px', fontSize: 'clamp(2rem, 4vw, 3rem)', fontWeight: 900, color: '#f9fafb', letterSpacing: '-0.03em', lineHeight: 1.1 }}>
-              Pilot Car Certification<br />
-              <span style={{ color: '#f59e0b' }}>Timelines & Reciprocity</span>
-            </h1>
-            <p style={{ margin: '0 0 2rem', fontSize: '1.05rem', color: '#94a3b8', lineHeight: 1.65, maxWidth: 640 }}>
-              Understand exactly how long it takes and what it costs to get legally certified in each state, plus a live reciprocity matrix so you know where your current badge works.
-            </p>
-          </div>
-        </div>
-
-        <div style={{ maxWidth: 1100, margin: '0 auto', padding: '2.5rem 1.5rem' }}>
-          
-          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(340px, 1fr))', gap: 20, marginBottom: 48 }}>
-            {activeRecords.map((c) => (
-               <div key={c.id} style={{
-                 background: 'rgba(255,255,255,0.02)', border: '1px solid rgba(255,255,255,0.07)',
-                 borderRadius: 16, overflow: 'hidden', padding: '20px'
-               }}>
-                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
-                   <div>
-                     <h3 style={{ margin: '0 0 4px', fontSize: 18, fontWeight: 800, color: '#f9fafb' }}>{c.jurisdiction_name}</h3>
-                     <span style={{ fontSize: 12, color: '#94a3b8', fontWeight: 600 }}>State / Province</span>
-                   </div>
-                   {c.requires_certification ? (
-                     <span style={{ display: 'flex', alignItems: 'center', gap: 4, padding: '4px 10px', background: 'rgba(245,158,11,0.1)', color: '#f59e0b', borderRadius: 8, fontSize: 11, fontWeight: 800, textTransform: 'uppercase' }}>
-                       <ShieldCheck style={{ width: 12, height: 12 }} /> Mandatory
-                     </span>
-                   ) : (
-                     <span style={{ display: 'flex', alignItems: 'center', gap: 4, padding: '4px 10px', background: 'rgba(34,197,94,0.1)', color: '#22c55e', borderRadius: 8, fontSize: 11, fontWeight: 800, textTransform: 'uppercase' }}>
-                       <Zap style={{ width: 12, height: 12 }} /> No Cert Required
-                     </span>
-                   )}
-                 </div>
-
-                 {c.requires_certification && (
-                   <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12, marginBottom: 16 }}>
-                     <div style={{ background: 'rgba(0,0,0,0.2)', padding: '12px', borderRadius: 8, border: '1px solid rgba(255,255,255,0.03)' }}>
-                       <div style={{ fontSize: 10, color: '#6b7280', textTransform: 'uppercase', fontWeight: 700, marginBottom: 4 }}>Training Required</div>
-                       <div style={{ fontSize: 16, fontWeight: 800, color: '#f9fafb' }}>{c.training_hours} <span style={{ fontSize: 11, color: '#94a3b8', fontWeight: 600 }}>hrs</span></div>
-                     </div>
-                     <div style={{ background: 'rgba(0,0,0,0.2)', padding: '12px', borderRadius: 8, border: '1px solid rgba(255,255,255,0.03)' }}>
-                       <div style={{ fontSize: 10, color: '#6b7280', textTransform: 'uppercase', fontWeight: 700, marginBottom: 4 }}>Total Cost</div>
-                       <div style={{ fontSize: 16, fontWeight: 800, color: '#f9fafb' }}>${c.certification_cost}</div>
-                     </div>
-                   </div>
-                 )}
-
-                 {c.reciprocity_states && c.reciprocity_states.length > 0 && (
-                   <div>
-                     <div style={{ fontSize: 11, color: '#94a3b8', textTransform: 'uppercase', fontWeight: 700, marginBottom: 8, display: 'flex', alignItems: 'center', gap: 4 }}>
-                       <Map style={{ width: 12, height: 12 }} /> Honored by:
-                     </div>
-                     <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
-                       {c.reciprocity_states.map((s) => (
-                         <span key={s} style={{ padding: '2px 8px', background: 'rgba(255,255,255,0.05)', color: '#cbd5e1', fontSize: 11, fontWeight: 700, borderRadius: 6, border: '1px solid rgba(255,255,255,0.1)' }}>
-                           {s}
-                         </span>
-                       ))}
-                     </div>
-                   </div>
-                 )}
-               </div>
-            ))}
-          </div>
-
-          <NoDeadEndBlock
-            heading="Update Your Profile"
-            moves={[
-              { href: '/claim', icon: 'âœ…', title: 'Claim Your Profile', desc: 'Add your certifications', primary: true, color: '#f59e0b' },
-              { href: '/forms', icon: 'ðŸ“„', title: 'Forms Hub', desc: 'Auto-fill compliance forms' },
-            ]}
-          />
-        </div>
-      </div>
+      <CertificationTimelineClient paths={activeRecords} />
     </>
   );
 }

--- a/lib/tools/certificationTimeline.ts
+++ b/lib/tools/certificationTimeline.ts
@@ -1,0 +1,164 @@
+export type CertificationPath = {
+  id: string;
+  jurisdiction_code: string;
+  jurisdiction_name: string;
+  requires_certification: boolean;
+  training_hours: number | null;
+  certification_cost: number | null;
+  renewal_period_years: number | null;
+  reciprocity_states: string[] | null;
+};
+
+export type CertificationStudyPace = 'weekend' | 'part_time' | 'accelerated';
+
+export type CertificationTimelineInput = {
+  targetCode: string;
+  currentCredentialCode: string;
+  pace: CertificationStudyPace;
+  startDate: string;
+};
+
+export type CertificationTimelineResult = {
+  target: CertificationPath;
+  currentCredential: CertificationPath | null;
+  reciprocityLikely: boolean;
+  nativeCredentialActive: boolean;
+  estimatedDays: number;
+  readyDate: string;
+  trainingHours: number | null;
+  estimatedCost: number;
+  renewalPeriodYears: number | null;
+  steps: Array<{ label: string; days: number; detail: string }>;
+  warnings: string[];
+};
+
+export const certificationPaceLabels: Record<CertificationStudyPace, string> = {
+  weekend: 'Weekend pace',
+  part_time: 'Part-time weekday pace',
+  accelerated: 'Accelerated class pace',
+};
+
+const paceHoursPerWeek: Record<CertificationStudyPace, number> = {
+  weekend: 6,
+  part_time: 10,
+  accelerated: 24,
+};
+
+export function isCertificationStudyPace(value: string): value is CertificationStudyPace {
+  return Object.prototype.hasOwnProperty.call(paceHoursPerWeek, value);
+}
+
+function parseStartDate(value: string) {
+  const parsed = new Date(`${value}T12:00:00.000Z`);
+  return Number.isNaN(parsed.getTime()) ? new Date() : parsed;
+}
+
+function addDays(date: Date, days: number) {
+  const next = new Date(date);
+  next.setUTCDate(next.getUTCDate() + days);
+  return next;
+}
+
+function isoDate(date: Date) {
+  return date.toISOString().slice(0, 10);
+}
+
+export function calculateCertificationTimeline(
+  paths: CertificationPath[],
+  input: CertificationTimelineInput,
+): CertificationTimelineResult {
+  const target = paths.find((path) => path.jurisdiction_code === input.targetCode) ?? paths[0];
+  if (!target) {
+    throw new Error('At least one certification path is required.');
+  }
+
+  const currentCredential =
+    input.currentCredentialCode === 'none'
+      ? null
+      : paths.find((path) => path.jurisdiction_code === input.currentCredentialCode) ?? null;
+  const reciprocityLikely =
+    Boolean(currentCredential) &&
+    (target.jurisdiction_code === currentCredential?.jurisdiction_code ||
+      Boolean(target.reciprocity_states?.includes(currentCredential?.jurisdiction_code ?? '')));
+  const nativeCredentialActive = target.jurisdiction_code === currentCredential?.jurisdiction_code;
+
+  const trainingHours = target.training_hours === null ? null : Math.max(0, target.training_hours ?? 0);
+  const trainingHoursKnown = trainingHours !== null;
+  const estimatedCost = Math.max(0, target.certification_cost ?? 0);
+  const studyDays = target.requires_certification
+    ? trainingHoursKnown
+      ? Math.max(1, Math.ceil((trainingHours / paceHoursPerWeek[input.pace]) * 7))
+      : 14
+    : 0;
+  const paperworkDays = target.requires_certification ? 5 : 1;
+  const mvrDays = target.requires_certification ? 3 : 0;
+  const examDays = target.requires_certification && !reciprocityLikely ? 2 : 0;
+  const agencyReviewDays = target.requires_certification ? (reciprocityLikely ? 4 : 10) : 0;
+
+  const steps = nativeCredentialActive
+    ? [
+        {
+          label: 'Confirm active target credential',
+          days: 0,
+          detail: `You selected an active ${target.jurisdiction_name} credential for the target jurisdiction. Confirm expiration, insurance, equipment, and route-specific proof before dispatch.`,
+        },
+      ]
+    : target.requires_certification
+    ? [
+        {
+          label: reciprocityLikely ? 'Confirm reciprocity path' : 'Book approved training',
+          days: reciprocityLikely ? 2 : studyDays,
+          detail: reciprocityLikely
+            ? `${target.jurisdiction_name} appears to honor ${currentCredential?.jurisdiction_name}; confirm proof requirements before dispatch.`
+            : trainingHoursKnown
+              ? `Plan ${trainingHours} training hour${trainingHours === 1 ? '' : 's'} at ${certificationPaceLabels[input.pace].toLowerCase()}.`
+              : 'Training hours are not stored for this jurisdiction yet. Use this as a conservative planning hold until the official schedule is verified.',
+        },
+        {
+          label: 'Collect proof packet',
+          days: paperworkDays + mvrDays,
+          detail: 'Gather ID, MVR, insurance proof, training completion, photo/signature, and any state-specific forms.',
+        },
+        {
+          label: 'Exam or agency review',
+          days: examDays + agencyReviewDays,
+          detail: reciprocityLikely
+            ? 'Agency review may be shorter when reciprocity is accepted, but the final permit office controls.'
+            : 'Budget time for testing, background review, card issuance, or appointment availability.',
+        },
+      ]
+    : [
+        {
+          label: 'Confirm local operating rules',
+          days: 1,
+          detail: `${target.jurisdiction_name} is not marked as requiring pilot-car certification in the current data, but equipment, insurance, and permit conditions can still apply.`,
+        },
+      ];
+
+  const estimatedDays = steps.reduce((sum, step) => sum + step.days, 0);
+  const readyDate = isoDate(addDays(parseStartDate(input.startDate), estimatedDays));
+  const warnings = [
+    target.requires_certification
+      ? 'Final eligibility depends on the official issuing authority, not this estimator.'
+      : 'No-certification states can still require permits, insurance, lighting, signs, or route-specific escort proof.',
+    target.requires_certification && !trainingHoursKnown
+      ? 'Training hours are missing for this jurisdiction; do not quote a firm ready date until the official course schedule is verified.'
+      : '',
+    estimatedCost === 0 ? 'No cost value is stored for this jurisdiction yet; verify fee schedules before quoting.' : '',
+    !target.renewal_period_years ? 'Renewal period is not stored for this jurisdiction yet.' : '',
+  ].filter((warning): warning is string => Boolean(warning));
+
+  return {
+    target,
+    currentCredential,
+    reciprocityLikely,
+    nativeCredentialActive,
+    estimatedDays,
+    readyDate,
+    trainingHours,
+    estimatedCost,
+    renewalPeriodYears: target.renewal_period_years,
+    steps,
+    warnings,
+  };
+}

--- a/tests/unit/certification-timeline.test.ts
+++ b/tests/unit/certification-timeline.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+import {
+  calculateCertificationTimeline,
+  type CertificationPath,
+} from '@/lib/tools/certificationTimeline';
+
+const paths: CertificationPath[] = [
+  {
+    id: 'wa',
+    jurisdiction_code: 'WA',
+    jurisdiction_name: 'Washington',
+    requires_certification: true,
+    training_hours: 24,
+    certification_cost: 425,
+    renewal_period_years: 3,
+    reciprocity_states: ['UT'],
+  },
+  {
+    id: 'ut',
+    jurisdiction_code: 'UT',
+    jurisdiction_name: 'Utah',
+    requires_certification: true,
+    training_hours: 16,
+    certification_cost: 300,
+    renewal_period_years: 4,
+    reciprocity_states: ['WA'],
+  },
+  {
+    id: 'az',
+    jurisdiction_code: 'AZ',
+    jurisdiction_name: 'Arizona',
+    requires_certification: false,
+    training_hours: null,
+    certification_cost: null,
+    renewal_period_years: null,
+    reciprocity_states: null,
+  },
+  {
+    id: 'ny',
+    jurisdiction_code: 'NY',
+    jurisdiction_name: 'New York',
+    requires_certification: true,
+    training_hours: null,
+    certification_cost: 0,
+    renewal_period_years: null,
+    reciprocity_states: [],
+  },
+];
+
+describe('calculateCertificationTimeline', () => {
+  it('builds a planning timeline from training hours, paperwork, exam, and review time', () => {
+    const result = calculateCertificationTimeline(paths, {
+      targetCode: 'WA',
+      currentCredentialCode: 'none',
+      pace: 'part_time',
+      startDate: '2026-05-22',
+    });
+
+    expect(result.target.jurisdiction_code).toBe('WA');
+    expect(result.reciprocityLikely).toBe(false);
+    expect(result.estimatedDays).toBe(37);
+    expect(result.readyDate).toBe('2026-06-28');
+    expect(result.steps.map((step) => step.label)).toEqual([
+      'Book approved training',
+      'Collect proof packet',
+      'Exam or agency review',
+    ]);
+  });
+
+  it('shortens the path when the selected credential is reciprocal', () => {
+    const result = calculateCertificationTimeline(paths, {
+      targetCode: 'UT',
+      currentCredentialCode: 'WA',
+      pace: 'weekend',
+      startDate: '2026-05-22',
+    });
+
+    expect(result.reciprocityLikely).toBe(true);
+    expect(result.currentCredential?.jurisdiction_code).toBe('WA');
+    expect(result.estimatedDays).toBe(14);
+    expect(result.steps[0]?.label).toBe('Confirm reciprocity path');
+  });
+
+  it('keeps no-certification jurisdictions honest instead of inventing training', () => {
+    const result = calculateCertificationTimeline(paths, {
+      targetCode: 'AZ',
+      currentCredentialCode: 'none',
+      pace: 'accelerated',
+      startDate: '2026-05-22',
+    });
+
+    expect(result.trainingHours).toBeNull();
+    expect(result.estimatedCost).toBe(0);
+    expect(result.estimatedDays).toBe(1);
+    expect(result.warnings[0]).toContain('No-certification states');
+  });
+
+  it('treats missing required training hours as unknown instead of near-zero effort', () => {
+    const result = calculateCertificationTimeline(paths, {
+      targetCode: 'NY',
+      currentCredentialCode: 'none',
+      pace: 'accelerated',
+      startDate: '2026-05-22',
+    });
+
+    expect(result.trainingHours).toBeNull();
+    expect(result.estimatedDays).toBeGreaterThan(1);
+    expect(result.warnings).toContain(
+      'Training hours are missing for this jurisdiction; do not quote a firm ready date until the official course schedule is verified.',
+    );
+  });
+
+  it('short-circuits when the selected credential already matches the target', () => {
+    const result = calculateCertificationTimeline(paths, {
+      targetCode: 'WA',
+      currentCredentialCode: 'WA',
+      pace: 'part_time',
+      startDate: '2026-05-22',
+    });
+
+    expect(result.nativeCredentialActive).toBe(true);
+    expect(result.estimatedDays).toBe(0);
+    expect(result.readyDate).toBe('2026-05-22');
+    expect(result.steps[0]?.label).toBe('Confirm active target credential');
+  });
+
+  it('rejects inherited keys in the study pace guard', async () => {
+    const { isCertificationStudyPace } = await import('@/lib/tools/certificationTimeline');
+
+    expect(isCertificationStudyPace('part_time')).toBe(true);
+    expect(isCertificationStudyPace('toString')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Replaces the static certification timeline grid with an interactive estimator backed by `hc_certification_paths`
- Adds reusable certification timeline calculation logic for training hours, fees, reciprocity, renewal, and ready-date planning
- Adds focused unit coverage for standard, reciprocal, and no-certification paths

## Verification
- `cmd /c npm test -- tests/unit/certification-timeline.test.ts`
- `cmd /c npm run typecheck`
- `cmd /c npm run build`
- `cmd /c npm run lint`

## Notes
- Uses stored registry data only; no fake jurisdiction rules were hardcoded.
- Build completed with existing unrelated warnings for Tailwind module type, edge runtime static generation, and invalid local Supabase API key on unrelated pages.