### PR TITLE
Build corridor pricing estimator

### DIFF
--- a/app/(public)/tools/corridor-pricing/CorridorPricingClient.tsx
+++ b/app/(public)/tools/corridor-pricing/CorridorPricingClient.tsx
@@ -1,0 +1,244 @@
+'use client';
+
+import Link from 'next/link';
+import { useMemo, useState } from 'react';
+import {
+  calculateCorridorPricing,
+  latestByCorridor,
+  type CorridorPricingRecord,
+} from '@/lib/tools/corridorPricing';
+
+function money(value: number) {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+function numberValue(value: string, fallback: number) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function labelFromSlug(slug: string) {
+  return slug.replace(/-/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+export function CorridorPricingClient({ records }: { records: CorridorPricingRecord[] }) {
+  const corridors = useMemo(() => latestByCorridor(records), [records]);
+  const [selectedSlug, setSelectedSlug] = useState(corridors[0]?.slug ?? 'manual');
+  const selected = corridors.find((corridor) => corridor.slug === selectedSlug)?.current ?? null;
+  const manualMode = !selected;
+
+  const [manualName, setManualName] = useState('Manual corridor');
+  const [routeMiles, setRouteMiles] = useState('650');
+  const [escortVehicles, setEscortVehicles] = useState('2');
+  const [baseRate, setBaseRate] = useState('2.25');
+  const [floorRate, setFloorRate] = useState('1.75');
+  const [ceilingRate, setCeilingRate] = useState('3.25');
+  const [volumeIndex, setVolumeIndex] = useState('50');
+  const [deadheadPercent, setDeadheadPercent] = useState('15');
+  const [waitHours, setWaitHours] = useState('4');
+  const [waitHourlyRate, setWaitHourlyRate] = useState('85');
+
+  const effectiveBase = selected?.avg_rate_per_mile ?? numberValue(baseRate, 2.25);
+  const effectiveFloor = selected?.min_rate_per_mile ?? numberValue(floorRate, 1.75);
+  const effectiveCeiling = selected?.max_rate_per_mile ?? numberValue(ceilingRate, 3.25);
+  const effectiveVolume = selected?.volume_index ?? numberValue(volumeIndex, 50);
+
+  const result = useMemo(
+    () =>
+      calculateCorridorPricing({
+        routeMiles: numberValue(routeMiles, 650),
+        escortVehicles: numberValue(escortVehicles, 2),
+        baseRatePerMile: effectiveBase,
+        floorRatePerMile: effectiveFloor,
+        ceilingRatePerMile: effectiveCeiling,
+        volumeIndex: effectiveVolume,
+        deadheadPercent: numberValue(deadheadPercent, 15),
+        waitHours: numberValue(waitHours, 4),
+        waitHourlyRate: numberValue(waitHourlyRate, 85),
+      }),
+    [
+      deadheadPercent,
+      effectiveBase,
+      effectiveCeiling,
+      effectiveFloor,
+      effectiveVolume,
+      escortVehicles,
+      routeMiles,
+      waitHourlyRate,
+      waitHours,
+    ],
+  );
+
+  const currentName = selected ? labelFromSlug(selected.corridor_slug) : manualName || 'Manual corridor';
+
+  return (
+    <div data-hc-topic-hero="manual" className="min-h-screen bg-[#07110F] text-white">
+      <section className="border-b border-emerald-400/10">
+        <div className="mx-auto max-w-6xl px-4 py-12">
+          <div className="mb-4 flex items-center gap-2 text-xs font-bold uppercase tracking-[0.2em] text-emerald-300">
+            <Link href="/tools" className="hover:text-white">Tools</Link>
+            <span>/</span>
+            <span>Pricing</span>
+          </div>
+          <h1 className="max-w-4xl text-3xl font-black tracking-tight md:text-5xl">
+            Corridor Pricing Estimator
+          </h1>
+          <p className="mt-4 max-w-3xl text-base leading-7 text-slate-300">
+            Estimate pilot car lane pricing from stored corridor rate signals or manual quote inputs.
+            Use this as a negotiation range, not a binding rate card.
+          </p>
+          <div className="mt-6 grid gap-3 sm:grid-cols-3">
+            <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+              <div className="text-2xl font-black text-emerald-300">{corridors.length}</div>
+              <div className="text-xs font-bold uppercase tracking-wider text-slate-400">Stored corridors loaded</div>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+              <div className="text-2xl font-black text-emerald-300">{result.billableMiles}</div>
+              <div className="text-xs font-bold uppercase tracking-wider text-slate-400">Billable miles modeled</div>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+              <div className="text-2xl font-black text-emerald-300">{effectiveVolume}/100</div>
+              <div className="text-xs font-bold uppercase tracking-wider text-slate-400">Volume index used</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <main className="mx-auto grid max-w-6xl gap-6 px-4 py-8 lg:grid-cols-[1fr_380px]">
+        <section className="rounded-2xl border border-white/10 bg-[#0D1B18] p-5">
+          <h2 className="text-lg font-black">Pricing Inputs</h2>
+          {corridors.length === 0 && (
+            <div className="mt-4 rounded-xl border border-amber-400/20 bg-amber-400/10 p-4 text-sm leading-6 text-amber-100">
+              No stored corridor pricing rows loaded in this environment. Manual mode is active and
+              only uses values you enter here.
+            </div>
+          )}
+          <div className="mt-5 grid gap-4 sm:grid-cols-2">
+            <label className="block">
+              <span className="text-xs font-bold uppercase tracking-wider text-slate-400">Corridor</span>
+              {corridors.length > 0 ? (
+                <select
+                  value={selectedSlug}
+                  onChange={(event) => setSelectedSlug(event.target.value)}
+                  className="mt-2 w-full rounded-xl border border-white/10 bg-[#07110F] px-3 py-3 text-white outline-none focus:border-emerald-300"
+                >
+                  {corridors.map((corridor) => (
+                    <option key={corridor.slug} value={corridor.slug}>
+                      {labelFromSlug(corridor.slug)}
+                    </option>
+                  ))}
+                  <option value="manual">Manual corridor</option>
+                </select>
+              ) : (
+                <input
+                  value={manualName}
+                  onChange={(event) => setManualName(event.target.value)}
+                  className="mt-2 w-full rounded-xl border border-white/10 bg-[#07110F] px-3 py-3 text-white outline-none focus:border-emerald-300"
+                />
+              )}
+            </label>
+            {[
+              ['Route miles', routeMiles, setRouteMiles],
+              ['Escort vehicles', escortVehicles, setEscortVehicles],
+              ['Deadhead %', deadheadPercent, setDeadheadPercent],
+              ['Wait hours', waitHours, setWaitHours],
+              ['Wait hourly rate', waitHourlyRate, setWaitHourlyRate],
+            ].map(([label, value, setter]) => (
+              <label key={label as string} className="block">
+                <span className="text-xs font-bold uppercase tracking-wider text-slate-400">{label as string}</span>
+                <input
+                  type="number"
+                  min={0}
+                  value={value as string}
+                  onChange={(event) => (setter as (value: string) => void)(event.target.value)}
+                  className="mt-2 w-full rounded-xl border border-white/10 bg-[#07110F] px-3 py-3 text-white outline-none focus:border-emerald-300"
+                />
+              </label>
+            ))}
+          </div>
+
+          {manualMode && (
+            <div className="mt-4 grid gap-4 sm:grid-cols-2">
+              {[
+                ['Floor rate / mi', floorRate, setFloorRate],
+                ['Base rate / mi', baseRate, setBaseRate],
+                ['Ceiling rate / mi', ceilingRate, setCeilingRate],
+                ['Volume index', volumeIndex, setVolumeIndex],
+              ].map(([label, value, setter]) => (
+                <label key={label as string} className="block">
+                  <span className="text-xs font-bold uppercase tracking-wider text-slate-400">{label as string}</span>
+                  <input
+                    type="number"
+                    min={0}
+                    value={value as string}
+                    onChange={(event) => (setter as (value: string) => void)(event.target.value)}
+                    className="mt-2 w-full rounded-xl border border-white/10 bg-[#07110F] px-3 py-3 text-white outline-none focus:border-emerald-300"
+                  />
+                </label>
+              ))}
+            </div>
+          )}
+
+          <div className="mt-6 rounded-2xl border border-emerald-300/20 bg-emerald-300/10 p-5">
+            <div className="text-xs font-bold uppercase tracking-[0.18em] text-emerald-300">Planning midpoint</div>
+            <div className="mt-2 text-4xl font-black">{money(result.midpoint)}</div>
+            <p className="mt-2 text-sm leading-6 text-slate-300">
+              {currentName}: {money(result.floor)} floor to {money(result.ceiling)} ceiling after
+              billable miles, escort count, demand pressure, and wait time.
+            </p>
+          </div>
+        </section>
+
+        <aside className="space-y-5">
+          <section className="rounded-2xl border border-white/10 bg-[#0D1B18] p-5">
+            <h2 className="text-lg font-black">Range Breakdown</h2>
+            <div className="mt-4 grid gap-3">
+              {[
+                ['Floor', money(result.floor)],
+                ['Midpoint', money(result.midpoint)],
+                ['Ceiling', money(result.ceiling)],
+                ['Wait charge', money(result.waitCharge)],
+                ['Demand multiplier', `${result.demandMultiplier.toFixed(2)}x`],
+              ].map(([label, value]) => (
+                <div key={label} className="flex items-center justify-between rounded-xl border border-white/10 bg-[#07110F] p-3">
+                  <span className="text-sm text-slate-400">{label}</span>
+                  <span className="font-black">{value}</span>
+                </div>
+              ))}
+            </div>
+          </section>
+          <section className="rounded-2xl border border-white/10 bg-[#0D1B18] p-5">
+            <h2 className="text-lg font-black">Next Actions</h2>
+            <div className="mt-4 grid gap-3">
+              <Link href="/available-now" className="rounded-xl border border-white/10 bg-[#07110F] px-4 py-3 text-sm font-bold text-white hover:border-emerald-300">Find escorts now</Link>
+              <Link href="/loads/post" className="rounded-xl border border-white/10 bg-[#07110F] px-4 py-3 text-sm font-bold text-white hover:border-emerald-300">Post a load</Link>
+              <Link href="/tools/pilot-car-rate-calculator" className="rounded-xl border border-white/10 bg-[#07110F] px-4 py-3 text-sm font-bold text-white hover:border-emerald-300">Check pilot car rate</Link>
+            </div>
+          </section>
+        </aside>
+      </main>
+
+      <section className="mx-auto max-w-6xl px-4 pb-12">
+        <div className="rounded-2xl border border-white/10 bg-[#0D1B18] p-5">
+          <h2 className="text-lg font-black">Stored Corridor Signals</h2>
+          <div className="mt-4 grid gap-3 md:grid-cols-2">
+            {(corridors.length > 0 ? corridors : [{ slug: 'manual', current: null, previous: null }]).map((corridor) => (
+              <div key={corridor.slug} className="rounded-xl border border-white/10 bg-[#07110F] p-4">
+                <div className="font-black">{corridor.current ? labelFromSlug(corridor.slug) : currentName}</div>
+                <div className="mt-2 text-sm text-slate-400">
+                  {corridor.current
+                    ? `$${corridor.current.min_rate_per_mile?.toFixed(2) ?? 'verify'} - $${corridor.current.max_rate_per_mile?.toFixed(2) ?? 'verify'} / mi, volume ${corridor.current.volume_index ?? 'verify'}/100`
+                    : 'Manual mode: no stored lane pricing rows loaded.'}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/(public)/tools/corridor-pricing/page.tsx
+++ b/app/(public)/tools/corridor-pricing/page.tsx
@@ -1,27 +1,17 @@
 import type { Metadata } from 'next';
 import { createClient } from '@/lib/supabase/server';
-import Link from 'next/link';
-import { LineChart, Route, ArrowRight, TrendingUp, TrendingDown, DollarSign } from 'lucide-react';
 import { ProofStrip } from '@/components/ui/ProofStrip';
-import { NoDeadEndBlock } from '@/components/ui/NoDeadEndBlock';
+import { CorridorPricingClient } from './CorridorPricingClient';
+import type { CorridorPricingRecord } from '@/lib/tools/corridorPricing';
 
 export const dynamic = 'force-dynamic';
 
 export const metadata: Metadata = {
-  title: 'Corridor Pricing History & Lane Rates | Haul Command',
-  description: 'Review heavy haul and pilot car lane rate planning ranges, pricing history, and spot market volume indexes across major oversize routing corridors.',
-  alternates: { canonical: 'https://www.haulcommand.com/tools/corridor-pricing' }
+  title: 'Corridor Pricing Estimator | Haul Command',
+  description:
+    'Estimate heavy haul and pilot car lane pricing from stored corridor rate signals or manual quote inputs. Confirm live quotes before booking.',
+  alternates: { canonical: 'https://www.haulcommand.com/tools/corridor-pricing' },
 };
-
-interface PricingHistory {
-  id: string;
-  corridor_slug: string;
-  month_start: string;
-  avg_rate_per_mile: number;
-  min_rate_per_mile: number;
-  max_rate_per_mile: number;
-  volume_index: number;
-}
 
 export default async function CorridorPricingHistoryPage() {
   const supabase = createClient();
@@ -31,126 +21,10 @@ export default async function CorridorPricingHistoryPage() {
     .order('corridor_slug', { ascending: true })
     .order('month_start', { ascending: false });
 
-  const activeRecords = (pricing || []) as PricingHistory[];
-
-  // Group by corridor to show the latest snapshot first
-  const groupedRecords = activeRecords.reduce((acc, record) => {
-    if (!acc[record.corridor_slug]) {
-      acc[record.corridor_slug] = [];
-    }
-    acc[record.corridor_slug].push(record);
-    return acc;
-  }, {} as Record<string, PricingHistory[]>);
-
   return (
     <>
       <ProofStrip variant="bar" />
-      <div data-hc-topic-hero="manual" style={{ minHeight: '100vh', background: '#050c14', color: '#e5e7eb', fontFamily: "'Inter', system-ui" }}>
-        
-        {/* -- HERO -- */}
-        <div style={{ position: 'relative', borderBottom: '1px solid rgba(255,255,255,0.05)', overflow: 'hidden' }}>
-          <div style={{ position: 'absolute', inset: 0, background: 'radial-gradient(ellipse 80% 50% at 50% -10%, rgba(16,185,129,0.08), transparent 70%)', pointerEvents: 'none' }} />
-          <div style={{ maxWidth: 1100, margin: '0 auto', padding: '3.5rem 1.5rem 3rem' }}>
-            <nav style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 11, color: '#4b5563', marginBottom: 20, textTransform: 'uppercase', letterSpacing: 1, fontWeight: 700 }}>
-              <Link href="/tools" style={{ color: '#6b7280', textDecoration: 'none' }}>Tools Hub</Link>
-              <span style={{ color: '#4b5563' }}>"º</span>
-              <span style={{ color: '#10b981' }}>Pricing & Rates</span>
-            </nav>
-            <h1 style={{ margin: '0 0 12px', fontSize: 'clamp(2rem, 4vw, 3rem)', fontWeight: 900, color: '#f9fafb', letterSpacing: '-0.03em', lineHeight: 1.1 }}>
-              Lane & Corridor<br />
-              <span style={{ color: '#10b981' }}>Pricing History</span>
-            </h1>
-            <p style={{ margin: '0 0 2rem', fontSize: '1.05rem', color: '#94a3b8', lineHeight: 1.65, maxWidth: 640 }}>
-              Compare stored and historical per-mile pricing signals for pilot cars across major industrial transit corridors. Confirm live quotes before booking.
-            </p>
-
-            <div style={{ display: 'inline-flex', alignItems: 'center', gap: 8, padding: '8px 16px', background: 'rgba(16,185,129,0.1)', border: '1px solid rgba(16,185,129,0.2)', borderRadius: 12, color: '#22c55e', fontSize: 13, fontWeight: 700 }}>
-              <LineChart style={{ width: 16, height: 16 }} />
-              Source-Backed Pricing Signals
-            </div>
-          </div>
-        </div>
-
-        <div style={{ maxWidth: 1100, margin: '0 auto', padding: '2.5rem 1.5rem' }}>
-          
-          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(360px, 1fr))', gap: 24, marginBottom: 48 }}>
-            {Object.entries(groupedRecords).map(([slug, records]) => {
-               const current = records[0];
-               const previous = records[1];
-               const trend = previous ? (current.avg_rate_per_mile > previous.avg_rate_per_mile ? 'up' : current.avg_rate_per_mile < previous.avg_rate_per_mile ? 'down' : 'flat') : 'flat';
-               
-               return (
-                  <div key={slug} style={{
-                    background: 'rgba(255,255,255,0.02)', border: '1px solid rgba(255,255,255,0.07)',
-                    borderRadius: 16, overflow: 'hidden'
-                  }}>
-                    <div style={{ padding: '20px' }}>
-                      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 16 }}>
-                        <div>
-                          <h3 style={{ margin: '0 0 4px', fontSize: 18, fontWeight: 800, color: '#f9fafb', textTransform: 'uppercase', letterSpacing: 0.5 }}>{slug.replace(/-/g, ' ')}</h3>
-                          <span style={{ fontSize: 12, color: '#64748b', fontWeight: 600 }}>As of {new Date(current.month_start).toLocaleDateString('en-US', { month: 'short', year: 'numeric' })}</span>
-                        </div>
-                        <div style={{ 
-                           display: 'flex', alignItems: 'center', gap: 6, padding: '6px 12px', borderRadius: 8,
-                           background: 'rgba(16,185,129,0.1)', color: '#10b981'
-                        }}>
-                           <Route style={{ width: 16, height: 16 }} />
-                           <span style={{ fontSize: 12, fontWeight: 700 }}>Indexed Lane</span>
-                        </div>
-                      </div>
-
-                      <div style={{ padding: '20px', background: 'rgba(0,0,0,0.3)', borderRadius: 12, border: '1px solid rgba(255,255,255,0.03)', marginBottom: 16 }}>
-                          <div style={{ fontSize: 11, color: '#94a3b8', textTransform: 'uppercase', fontWeight: 700, letterSpacing: 0.5, marginBottom: 4 }}>Average Spot Rate</div>
-                          <div style={{ display: 'flex', alignItems: 'flex-end', gap: 12 }}>
-                              <div style={{ display: 'flex', alignItems: 'baseline', gap: 2 }}>
-                                  <DollarSign style={{ width: 20, height: 20, color: '#10b981', alignSelf: 'center' }} />
-                                  <span style={{ fontSize: 36, fontWeight: 900, color: '#f9fafb', lineHeight: 1 }}>{current.avg_rate_per_mile.toFixed(2)}</span>
-                                  <span style={{ fontSize: 14, color: '#64748b', fontWeight: 600 }}>/ mi</span>
-                              </div>
-                              {previous && (
-                                <div style={{ display: 'flex', alignItems: 'center', gap: 4, paddingBottom: 4, color: trend === 'up' ? '#10b981' : trend === 'down' ? '#ef4444' : '#64748b' }}>
-                                    {trend === 'up' ? <TrendingUp style={{ width: 14, height: 14 }} /> : trend === 'down' ? <TrendingDown style={{ width: 14, height: 14 }} /> : null}
-                                    <span style={{ fontSize: 12, fontWeight: 700 }}>{Math.abs(current.avg_rate_per_mile - previous.avg_rate_per_mile).toFixed(2)} vs last mo</span>
-                                </div>
-                              )}
-                          </div>
-                      </div>
-
-                      <div style={{ display: 'flex', justifyContent: 'space-between', padding: '0 8px' }}>
-                          <div>
-                             <span style={{ display: 'block', fontSize: 10, color: '#64748b', textTransform: 'uppercase', fontWeight: 700 }}>Floor Rate</span>
-                             <span style={{ fontSize: 14, fontWeight: 800, color: '#cbd5e1' }}>${current.min_rate_per_mile.toFixed(2)}</span>
-                          </div>
-                          <div style={{ textAlign: 'center' }}>
-                             <span style={{ display: 'block', fontSize: 10, color: '#64748b', textTransform: 'uppercase', fontWeight: 700 }}>Ceiling Rate</span>
-                             <span style={{ fontSize: 14, fontWeight: 800, color: '#cbd5e1' }}>${current.max_rate_per_mile.toFixed(2)}</span>
-                          </div>
-                          <div style={{ textAlign: 'right' }}>
-                             <span style={{ display: 'block', fontSize: 10, color: '#64748b', textTransform: 'uppercase', fontWeight: 700 }}>Volume Index</span>
-                             <span style={{ fontSize: 14, fontWeight: 800, color: '#3b82f6' }}>{current.volume_index}/100</span>
-                          </div>
-                      </div>
-                    </div>
-
-                    <div style={{ borderTop: '1px solid rgba(255,255,255,0.05)', padding: '12px 20px', background: 'rgba(0,0,0,0.2)' }}>
-                      <Link href={`/corridors/${slug}`} style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 6, padding: '10px', background: 'rgba(16,185,129,0.1)', color: '#10b981', borderRadius: 8, fontSize: 13, fontWeight: 700, textDecoration: 'none' }}>
-                        View Corridor Intelligence <ArrowRight style={{ width: 14, height: 14 }} />
-                      </Link>
-                    </div>
-                  </div>
-               );
-            })}
-          </div>
-
-          <NoDeadEndBlock
-            heading="Negotiate with Confidence"
-            moves={[
-              { href: '/available-now', icon: 'ðŸŸ¢', title: 'Find Escorts Now', desc: 'Secure capacity on these lanes', primary: true, color: '#10b981' },
-              { href: '/loads', icon: 'ðŸ“¦', title: 'Post a Load', desc: 'Broadcast to active operators' },
-            ]}
-          />
-        </div>
-      </div>
+      <CorridorPricingClient records={(pricing || []) as CorridorPricingRecord[]} />
     </>
   );
 }

--- a/lib/tools/corridorPricing.ts
+++ b/lib/tools/corridorPricing.ts
@@ -1,0 +1,82 @@
+export type CorridorPricingRecord = {
+  id: string;
+  corridor_slug: string;
+  month_start: string;
+  avg_rate_per_mile: number | null;
+  min_rate_per_mile: number | null;
+  max_rate_per_mile: number | null;
+  volume_index: number | null;
+};
+
+export type CorridorPricingInput = {
+  routeMiles: number;
+  escortVehicles: number;
+  baseRatePerMile: number;
+  floorRatePerMile: number;
+  ceilingRatePerMile: number;
+  volumeIndex: number;
+  deadheadPercent: number;
+  waitHours: number;
+  waitHourlyRate: number;
+};
+
+export type CorridorPricingResult = {
+  billableMiles: number;
+  floor: number;
+  midpoint: number;
+  ceiling: number;
+  waitCharge: number;
+  demandMultiplier: number;
+  confidence: 'stored_lane' | 'manual_estimate';
+  warnings: string[];
+};
+
+function clamp(value: number, min: number, max: number) {
+  if (!Number.isFinite(value)) return min;
+  return Math.min(max, Math.max(min, value));
+}
+
+export function calculateCorridorPricing(input: CorridorPricingInput): CorridorPricingResult {
+  const routeMiles = Math.max(1, input.routeMiles || 1);
+  const escortVehicles = clamp(input.escortVehicles || 1, 1, 8);
+  const floorRate = Math.max(0, input.floorRatePerMile || 0);
+  const baseRate = Math.max(floorRate, input.baseRatePerMile || floorRate);
+  const ceilingRate = Math.max(baseRate, input.ceilingRatePerMile || baseRate);
+  const deadheadPercent = clamp(input.deadheadPercent || 0, 0, 100);
+  const volumeIndex = clamp(input.volumeIndex || 50, 0, 100);
+  const waitHours = Math.max(0, input.waitHours || 0);
+  const waitHourlyRate = Math.max(0, input.waitHourlyRate || 0);
+
+  const demandMultiplier = 1 + (volumeIndex - 50) / 250;
+  const billableMiles = Math.round(routeMiles * (1 + deadheadPercent / 100));
+  const waitCharge = waitHours * waitHourlyRate * escortVehicles;
+
+  return {
+    billableMiles,
+    floor: Math.round(billableMiles * floorRate * escortVehicles + waitCharge),
+    midpoint: Math.round(billableMiles * baseRate * demandMultiplier * escortVehicles + waitCharge),
+    ceiling: Math.round(billableMiles * ceilingRate * demandMultiplier * escortVehicles + waitCharge),
+    waitCharge: Math.round(waitCharge),
+    demandMultiplier,
+    confidence: 'manual_estimate',
+    warnings: [
+      'This is a planning range, not a binding quote. Confirm current availability, permits, insurance, route restrictions, and operator terms before booking.',
+      volumeIndex === 50
+        ? 'Volume index is neutral or unknown; use live quote collection for high-value moves.'
+        : '',
+    ].filter((warning): warning is string => Boolean(warning)),
+  };
+}
+
+export function latestByCorridor(records: CorridorPricingRecord[]) {
+  const grouped = new Map<string, CorridorPricingRecord[]>();
+  for (const record of records) {
+    const rows = grouped.get(record.corridor_slug) ?? [];
+    rows.push(record);
+    grouped.set(record.corridor_slug, rows);
+  }
+  return Array.from(grouped.entries()).map(([slug, rows]) => {
+    const sorted = [...rows].sort((a, b) => b.month_start.localeCompare(a.month_start));
+    return { slug, current: sorted[0], previous: sorted[1] ?? null };
+  });
+}

--- a/tests/unit/corridor-pricing.test.ts
+++ b/tests/unit/corridor-pricing.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { calculateCorridorPricing, latestByCorridor } from '@/lib/tools/corridorPricing';
+
+describe('calculateCorridorPricing', () => {
+  it('estimates a lane range from miles, escorts, demand, deadhead, and wait time', () => {
+    const result = calculateCorridorPricing({
+      routeMiles: 500,
+      escortVehicles: 2,
+      floorRatePerMile: 1.5,
+      baseRatePerMile: 2,
+      ceilingRatePerMile: 3,
+      volumeIndex: 75,
+      deadheadPercent: 10,
+      waitHours: 4,
+      waitHourlyRate: 80,
+    });
+
+    expect(result.billableMiles).toBe(550);
+    expect(result.waitCharge).toBe(640);
+    expect(result.demandMultiplier).toBeCloseTo(1.1);
+    expect(result.floor).toBe(2290);
+    expect(result.midpoint).toBe(3060);
+    expect(result.ceiling).toBe(4270);
+  });
+
+  it('keeps the latest row per corridor first', () => {
+    const rows = latestByCorridor([
+      { id: '1', corridor_slug: 'i-10', month_start: '2026-04-01', avg_rate_per_mile: 2, min_rate_per_mile: 1, max_rate_per_mile: 3, volume_index: 40 },
+      { id: '2', corridor_slug: 'i-10', month_start: '2026-05-01', avg_rate_per_mile: 3, min_rate_per_mile: 2, max_rate_per_mile: 4, volume_index: 60 },
+    ]);
+
+    expect(rows[0]?.current.id).toBe('2');
+    expect(rows[0]?.previous?.id).toBe('1');
+  });
+});


### PR DESCRIPTION
## Summary
- Replaces the thin corridor pricing history surface with an interactive corridor pricing estimator
- Uses stored `hc_corridor_pricing` rows when available and falls back to manual mode when rows are unavailable
- Adds reusable corridor pricing calculation logic and unit coverage

## Verification
- `cmd /c npm test -- tests/unit/corridor-pricing.test.ts`
- `cmd /c npm run typecheck`
- `cmd /c npm run lint`
- `cmd /c npm run build`

## Notes
- No fake live corridor data is hardcoded. Manual mode only uses user-entered values when stored corridor rows are absent.
- Build completed with existing unrelated warnings for Tailwind module type, edge runtime static generation, and invalid local Supabase API key on unrelated pages.