### PR TITLE
Wire directory search aliases

### DIFF
--- a/app/api/directory/search/route.ts
+++ b/app/api/directory/search/route.ts
@@ -1,6 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { searchOperators } from '@/lib/typesense/sync';
+import {
+  buildAliasAwareOrFilter,
+  resolveDirectorySearchAliases,
+} from '@/lib/directory/search-aliases';
 
 /**
  * GET /api/directory/search
@@ -39,6 +43,7 @@ export async function GET(req: NextRequest) {
     const startRange = (page - 1) * limit;
     const endRange = startRange + limit - 1;
     const sortBy = searchParams.get('sort') ?? 'rank';
+    const searchAliases = q ? await resolveDirectorySearchAliases(supabase, q, country) : [];
 
     // Public directory search never exposes raw phone values. A prior version
     // treated any Authorization header as trusted and uncensored contact data.
@@ -114,7 +119,12 @@ export async function GET(req: NextRequest) {
 
     if (q) {
       hcQuery = hcQuery.or(
-        `name.ilike.%${q}%,locality.ilike.%${q}%,admin1_code.ilike.%${q}%,description.ilike.%${q}%`
+        buildAliasAwareOrFilter(
+          ['name', 'locality', 'admin1_code', 'description'],
+          'surface_category_key',
+          q,
+          searchAliases,
+        )
       );
     }
     if (country) hcQuery = hcQuery.eq('country_code', country.toUpperCase());
@@ -218,7 +228,12 @@ export async function GET(req: NextRequest) {
 
       if (q) {
         opQuery = opQuery.or(
-          `name.ilike.%${q}%,city.ilike.%${q}%,admin1_code.ilike.%${q}%`
+          buildAliasAwareOrFilter(
+            ['name', 'city', 'admin1_code'],
+            'role_primary',
+            q,
+            searchAliases,
+          )
         );
       }
       if (country) opQuery = opQuery.eq('country_code', country.toUpperCase());

--- a/lib/directory/search-aliases.ts
+++ b/lib/directory/search-aliases.ts
@@ -1,0 +1,96 @@
+export type DirectorySearchAlias = {
+  alias: string;
+  alias_norm: string | null;
+  canonical: string;
+  canonical_kind: string;
+  canonical_ref: string | null;
+  country_code: string | null;
+  confidence: number | string;
+};
+
+const ALIAS_SELECT =
+  "alias, alias_norm, canonical, canonical_kind, canonical_ref, country_code, confidence";
+
+export function normalizeDirectoryAliasQuery(value: string): string {
+  return value.trim().toLowerCase().replace(/[-_]+/g, " ").replace(/\s+/g, " ");
+}
+
+function cleanPostgrestTerm(value: string): string {
+  return value.trim().replace(/[%,()]/g, " ").replace(/\s+/g, " ");
+}
+
+function cleanPostgrestEquality(value: string): string {
+  return value.trim().replace(/[^A-Za-z0-9_-]/g, "");
+}
+
+function unique(values: string[]): string[] {
+  return Array.from(new Set(values.filter(Boolean)));
+}
+
+export function getAliasCanonicalTargets(aliases: DirectorySearchAlias[]): string[] {
+  return unique(
+    aliases.flatMap((alias) => [
+      cleanPostgrestEquality(alias.canonical),
+      cleanPostgrestEquality(alias.canonical_ref ?? ""),
+    ]),
+  );
+}
+
+export function getAliasAwareSearchTerms(
+  rawQuery: string,
+  aliases: DirectorySearchAlias[],
+): string[] {
+  const aliasTerms = aliases.flatMap((alias) => [
+    alias.alias,
+    alias.canonical,
+    alias.canonical.replace(/_/g, " "),
+    alias.canonical_ref ?? "",
+    alias.canonical_ref?.replace(/_/g, " ") ?? "",
+  ]);
+
+  return unique([rawQuery, ...aliasTerms].map(cleanPostgrestTerm)).slice(0, 12);
+}
+
+export function buildAliasAwareOrFilter(
+  textFields: string[],
+  canonicalField: string,
+  rawQuery: string,
+  aliases: DirectorySearchAlias[],
+): string {
+  const searchTerms = getAliasAwareSearchTerms(rawQuery, aliases);
+  const targets = getAliasCanonicalTargets(aliases);
+  const textClauses = textFields.flatMap((field) =>
+    searchTerms.map((term) => `${field}.ilike.%${term}%`),
+  );
+  const canonicalClauses = targets.map((target) => `${canonicalField}.eq.${target}`);
+
+  return [...textClauses, ...canonicalClauses].join(",");
+}
+
+export async function resolveDirectorySearchAliases(
+  supabase: any,
+  rawQuery: string,
+  countryCode?: string,
+): Promise<DirectorySearchAlias[]> {
+  const aliasNorm = normalizeDirectoryAliasQuery(rawQuery);
+  if (!aliasNorm) return [];
+
+  const { data, error } = await supabase
+    .from("hc_search_aliases")
+    .select(ALIAS_SELECT)
+    .eq("enabled", true)
+    .eq("alias_norm", aliasNorm)
+    .order("confidence", { ascending: false })
+    .limit(10);
+
+  if (error || !data) {
+    if (error) console.error("[directory-search] Alias lookup failed:", error);
+    return [];
+  }
+
+  const requestedCountry = countryCode.trim().toUpperCase();
+  return (data as DirectorySearchAlias[]).filter((alias) => {
+    if (!requestedCountry) return true;
+    return !alias.country_code || alias.country_code.toUpperCase() === requestedCountry;
+  });
+}

--- a/tests/unit/directory-search-aliases.test.ts
+++ b/tests/unit/directory-search-aliases.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildAliasAwareOrFilter,
+  getAliasAwareSearchTerms,
+  getAliasCanonicalTargets,
+  normalizeDirectoryAliasQuery,
+  type DirectorySearchAlias,
+} from "@/lib/directory/search-aliases";
+
+const restAreaAlias: DirectorySearchAlias = {
+  alias: "rest area",
+  alias_norm: "rest area",
+  canonical: "rest_area",
+  canonical_kind: "role",
+  canonical_ref: null,
+  country_code: null,
+  confidence: "1.00",
+};
+
+describe("directory search aliases", () => {
+  it("normalizes user wording the same way hc_search_aliases stores aliases", () => {
+    expect(normalizeDirectoryAliasQuery("  Rest-Area  ")).toBe("rest area");
+    expect(normalizeDirectoryAliasQuery("truck_stop")).toBe("truck stop");
+  });
+
+  it("adds canonical role/category terms without losing the user query", () => {
+    expect(getAliasAwareSearchTerms("rest area", [restAreaAlias])).toEqual([
+      "rest area",
+      "rest_area",
+    ]);
+    expect(getAliasCanonicalTargets([restAreaAlias])).toEqual(["rest_area"]);
+  });
+
+  it("builds a PostgREST OR filter that searches text and canonical category fields", () => {
+    expect(
+      buildAliasAwareOrFilter(["name", "locality"], "surface_category_key", "rest area", [
+        restAreaAlias,
+      ]),
+    ).toBe(
+      "name.ilike.%rest area%,name.ilike.%rest_area%,locality.ilike.%rest area%,locality.ilike.%rest_area%,surface_category_key.eq.rest_area",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- resolves user directory searches through `hc_search_aliases` before Supabase fallback search
- expands alias terms into canonical category/role filters for `hc_places` and `hc_global_operators`
- adds focused unit coverage for alias normalization and PostgREST OR filter construction

## Verification
- `npm test -- tests/unit/directory-search-aliases.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

## Data check
- production alias data maps `rest area -> rest_area` and `truck stop -> truck_stop`
- production indexed matches: `rest_area` 1,104; `truck_stop` 12,219