### PR TITLE
Expose directory search data failures

### DIFF
--- a/app/api/directory/search/route.ts
+++ b/app/api/directory/search/route.ts
@@ -153,7 +153,14 @@ export async function GET(req: NextRequest) {
 
     hcQuery = hcQuery.range(startRange, endRange);
 
-    const { data: hcData, count: hcCount } = await hcQuery;
+    const { data: hcData, count: hcCount, error: hcError } = await hcQuery;
+    if (hcError) {
+      console.error('[directory-search] hc_places query failed:', hcError);
+      return NextResponse.json(
+        { error: 'Directory search failed to load places', source: 'hc_places' },
+        { status: 502 }
+      );
+    }
 
     // ═══ Available Now: fetch live operator IDs ═══
     let liveOperatorIds: Set<string> | null = null;
@@ -247,7 +254,14 @@ export async function GET(req: NextRequest) {
       }
 
       opQuery = opQuery.range(startRange, endRange);
-      const { data: opData, count: opTotal } = await opQuery;
+      const { data: opData, count: opTotal, error: opError } = await opQuery;
+      if (opError) {
+        console.error('[directory-search] hc_global_operators query failed:', opError);
+        return NextResponse.json(
+          { error: 'Directory search failed to load operators', source: 'hc_global_operators' },
+          { status: 502 }
+        );
+      }
       opCount = opTotal ?? 0;
 
       opResults = (opData || []).map((op: any, index: number) => ({

--- a/supabase/migrations/20260522131500_allow_public_enabled_search_aliases.sql
+++ b/supabase/migrations/20260522131500_allow_public_enabled_search_aliases.sql
@@ -1,0 +1,18 @@
+grant select on table public.hc_search_aliases to anon, authenticated;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'hc_search_aliases'
+      and policyname = 'Public can read enabled search aliases'
+  ) then
+    create policy "Public can read enabled search aliases"
+      on public.hc_search_aliases
+      for select
+      to anon, authenticated
+      using (enabled = true);
+  end if;
+end $$;


### PR DESCRIPTION
## Summary
- returns a 502 when directory Supabase queries fail instead of reporting fake zero-result searches
- commits the enabled-alias public read policy that was applied to production for `hc_search_aliases`

## Verification
- `npm test -- tests/unit/directory-search-aliases.test.ts`
- `npm run typecheck`
- `npm run build`

## Production observation
- `/api/directory/search` currently returns zero for all queries, including no query; this patch makes that failure visible after deployment so the remaining Vercel/Supabase env problem is diagnosable instead of silent.