### PR TITLE
Allow public searchable place reads

### DIFF
--- a/supabase/migrations/20260522132500_allow_public_searchable_hc_places.sql
+++ b/supabase/migrations/20260522132500_allow_public_searchable_hc_places.sql
@@ -1,0 +1,16 @@
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'hc_places'
+      and policyname = 'Public can read searchable places'
+  ) then
+    create policy "Public can read searchable places"
+      on public.hc_places
+      for select
+      to anon, authenticated
+      using (status = 'published' and is_search_indexable = true);
+  end if;
+end $$;


### PR DESCRIPTION
## Summary
- commits the RLS policy already applied to production for public directory search reads on `hc_places`
- limits readable rows to the same search-safe predicate used by `/api/directory/search`: `status='published'` and `is_search_indexable=true`

## Verification
- production `/api/directory/search?q=rest%20area&limit=3` returns 200 with `rest_area` results
- production `/api/directory/search?q=truck%20stop&limit=3` returns 200 with `truck_stop` results
- production `/api/directory/search?q=stearman&limit=3` returns 200 with zero rows, matching the current lack of `steer_operator` entities