### PR TITLE
[fix] Harden live directory role browse and search fallbacks

### DIFF
--- a/app/(public)/tools/escort-requirement-calculator/page.tsx
+++ b/app/(public)/tools/escort-requirement-calculator/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function EscortRequirementCalculatorRedirect() {
+  redirect('/tools/escort-count-calculator');
+}

--- a/app/api/directory/search/route.ts
+++ b/app/api/directory/search/route.ts
@@ -44,6 +44,7 @@ export async function GET(req: NextRequest) {
     const endRange = startRange + limit - 1;
     const sortBy = searchParams.get('sort') ?? 'rank';
     const searchAliases = q ? await resolveDirectorySearchAliases(supabase, q, country) : [];
+    const sourceErrors: string[] = [];
 
     // Public directory search never exposes raw phone values. A prior version
     // treated any Authorization header as trusted and uncensored contact data.
@@ -154,12 +155,13 @@ export async function GET(req: NextRequest) {
     hcQuery = hcQuery.range(startRange, endRange);
 
     const { data: hcData, count: hcCount, error: hcError } = await hcQuery;
+    let safeHcData = hcData ?? [];
+    let safeHcCount = hcCount ?? 0;
     if (hcError) {
       console.error('[directory-search] hc_places query failed:', hcError);
-      return NextResponse.json(
-        { error: 'Directory search failed to load places', source: 'hc_places' },
-        { status: 502 }
-      );
+      sourceErrors.push('hc_places');
+      safeHcData = [];
+      safeHcCount = 0;
     }
 
     // ═══ Available Now: fetch live operator IDs ═══
@@ -175,7 +177,7 @@ export async function GET(req: NextRequest) {
     }
 
     // Map hc_places → unified shape
-    const hcResults = (hcData || []).map((row: any, index: number) => ({
+    const hcResults = safeHcData.map((row: any, index: number) => ({
       id: row.id,
       slug: row.slug,
       name: row.name || 'Service Business',
@@ -257,36 +259,33 @@ export async function GET(req: NextRequest) {
       const { data: opData, count: opTotal, error: opError } = await opQuery;
       if (opError) {
         console.error('[directory-search] hc_global_operators query failed:', opError);
-        return NextResponse.json(
-          { error: 'Directory search failed to load operators', source: 'hc_global_operators' },
-          { status: 502 }
-        );
+        sourceErrors.push('hc_global_operators');
+      } else {
+        opCount = opTotal ?? 0;
+        opResults = (opData || []).map((op: any, index: number) => ({
+          id: op.id,
+          slug: op.slug,
+          name: op.name || 'Escort Operator',
+          city: op.city,
+          state: op.admin1_code,
+          location: `${op.city}, ${op.admin1_code}`,
+          region_code: op.admin1_code,
+          country_code: op.country_code,
+          services: op.role_primary ? [op.role_primary] : [],
+          category: op.role_primary || 'pilot_car',
+          is_claimed: op.is_claimed === true,
+          rating: op.confidence_score ? (op.confidence_score / 20) : null,
+          review_count: 0,
+          rank_score: op.confidence_score ?? 0,
+          score: op.confidence_score ?? 50,
+          is_featured: (op.confidence_score ?? 0) > 80,
+          profile_completeness: 40,
+          source: 'operators',
+          badges: {},
+          equipment_tags: [],
+          is_available_now: false,
+        }));
       }
-      opCount = opTotal ?? 0;
-
-      opResults = (opData || []).map((op: any, index: number) => ({
-        id: op.id,
-        slug: op.slug,
-        name: op.name || 'Escort Operator',
-        city: op.city,
-        state: op.admin1_code,
-        location: `${op.city}, ${op.admin1_code}`,
-        region_code: op.admin1_code,
-        country_code: op.country_code,
-        services: op.role_primary ? [op.role_primary] : [],
-        category: op.role_primary || 'pilot_car',
-        is_claimed: op.is_claimed === true,
-        rating: op.confidence_score ? (op.confidence_score / 20) : null,
-        review_count: 0,
-        rank_score: op.confidence_score ?? 0,
-        score: op.confidence_score ?? 50,
-        is_featured: (op.confidence_score ?? 0) > 80,
-        profile_completeness: 40,
-        source: 'operators',
-        badges: {},
-        equipment_tags: [],
-        is_available_now: false,
-      }));
     }
 
     // ═════════════════════════════════════════
@@ -302,7 +301,7 @@ export async function GET(req: NextRequest) {
       return (b.rank_score ?? 0) - (a.rank_score ?? 0);
     });
 
-    const combinedTotal = (hcCount ?? 0) + opCount;
+    const combinedTotal = safeHcCount + opCount;
     const operators = allResults.slice(0, limit);
 
     return NextResponse.json({
@@ -313,7 +312,10 @@ export async function GET(req: NextRequest) {
       limit,
       total_pages: Math.ceil(combinedTotal / limit),
       has_more: (startRange + limit) < combinedTotal,
-      sources: { hc_places: hcCount ?? 0, operators: opCount },
+      sources: { hc_places: safeHcCount, operators: opCount },
+      data_issue: sourceErrors.length > 0
+        ? 'One or more directory sources could not be read. Results may be incomplete.'
+        : null,
       filters_applied: hasHardFilters ? {
         twic: filterTwic, hazmat: filterHazmat, highPole: filterHighPole,
         superload: filterSuperload, avCertified: filterAvCertified,
@@ -324,7 +326,8 @@ export async function GET(req: NextRequest) {
       headers: { 'Cache-Control': hasHardFilters ? 'private, no-cache' : 'public, s-maxage=60, stale-while-revalidate=120' },
     });
   } catch (error: any) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    console.error('[directory-search] request failed:', error);
+    return NextResponse.json({ error: 'Directory search is temporarily unavailable.' }, { status: 500 });
   }
 }
 

--- a/app/directory/[country]/[slug]/page.tsx
+++ b/app/directory/[country]/[slug]/page.tsx
@@ -13,6 +13,7 @@ import { stateFullName } from '@/lib/geo/state-names';
 import { DirectoryBackgroundShell } from '@/components/directory/DirectoryBackgroundShell';
 import {
   buildDirectoryMarketFilterPlan,
+  normalizeDirectoryCountry,
   type DirectoryMarketFilterPlan,
   type DirectorySurfaceView,
 } from '@/lib/directory/server-query';
@@ -62,6 +63,14 @@ function cityClaimHref(country: string, slug: string, listing?: string) {
 
 function rankDirectoryRecord(record: any) {
   return Number(record.rank_score ?? record.confidence_score ?? record.directory_quality_score ?? 0);
+}
+
+function displayRoleFromSlug(slug: string) {
+  return String(slug ?? '')
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\b\w/g, (char) => char.toUpperCase());
 }
 
 function buildMarketDirectAnswer(input: {
@@ -189,6 +198,14 @@ export default async function CityDirectoryPage({ params }: PageProps) {
   const { country, slug } = await params;
   // Guard: if params resolution fails for any reason, 404 cleanly
   if (!country || !slug) { notFound(); }
+
+  const firstSegmentCountry = normalizeDirectoryCountry(country);
+  const secondSegmentCountry = normalizeDirectoryCountry(slug);
+  if (!firstSegmentCountry && secondSegmentCountry) {
+    const roleQuery = displayRoleFromSlug(country);
+    redirect(`/directory?country=${secondSegmentCountry}&q=${encodeURIComponent(roleQuery)}`);
+  }
+
   const plan = buildDirectoryMarketFilterPlan({ country, slug });
   const countryUpper = plan.countryCode ?? country.toUpperCase();
 

--- a/app/directory/page.tsx
+++ b/app/directory/page.tsx
@@ -1,6 +1,4 @@
 import React from 'react';
-import { cookies } from 'next/headers';
-import { createServerClient } from '@supabase/ssr';
 import Link from 'next/link';
 import { AdGridSlot } from '@/components/home/AdGridSlot';
 import { LiveActivityFeed } from '@/components/feed/LiveActivityFeed';
@@ -18,6 +16,7 @@ import {
     resolveDirectoryCategoryFilter,
 } from '@/lib/directory/server-query';
 import { absoluteUrl, SITE_URL } from '@/lib/site-url';
+import { createClient as createSupabaseServerClient } from '@/lib/supabase/server';
 
 export const dynamic = 'force-dynamic';
 
@@ -83,20 +82,109 @@ const roleCoverage = [
     'Credentialed access labor',
 ];
 
-const roleCategoryLinks = [
-    { label: 'Pilot car operators', category: 'pilot-car' },
-    { label: 'Escort vehicles', category: 'escort' },
-    { label: 'High-pole escorts', category: 'high-pole' },
-    { label: 'Permit support', category: 'permit' },
-    { label: 'Route survey', category: 'route-survey' },
-    { label: 'Traffic control', category: 'traffic-control' },
-    { label: 'Staging yards', category: 'staging' },
-    { label: 'Truck stops', category: 'truck-stop' },
-    { label: 'Oversize parking', category: 'parking' },
-    { label: 'Mobile mechanics', category: 'repair' },
-    { label: 'Port support', category: 'port' },
-    { label: 'Weigh stations', category: 'weigh-station' },
-];
+type DirectoryRoleBrowseOption = {
+    key: string;
+    label: string;
+    family: string;
+    operators: number;
+    hasSupply: boolean;
+    source: 'supabase' | 'fallback';
+};
+
+function normalizeDirectoryRoleKey(value: unknown): string {
+    return String(value ?? '')
+        .trim()
+        .toLowerCase()
+        .replace(/[_\s]+/g, '-')
+        .replace(/[^a-z0-9-]/g, '')
+        .replace(/-+/g, '-')
+        .replace(/^-|-$/g, '');
+}
+
+function humanizeDirectoryRole(value: unknown): string {
+    const raw = String(value ?? '').trim();
+    if (!raw) return 'Heavy haul support';
+    return raw
+        .replace(/[_-]+/g, ' ')
+        .replace(/\s+/g, ' ')
+        .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function numberFromDirectoryRoleRow(row: any): number {
+    const value =
+        row?.operators ??
+        row?.operator_count ??
+        row?.entity_count ??
+        row?.source_backed_records ??
+        row?.listing_count ??
+        row?.record_count ??
+        row?.total_entities ??
+        0;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function fallbackDirectoryRoleOptions(): DirectoryRoleBrowseOption[] {
+    return roleCoverage.map((label) => ({
+        key: normalizeDirectoryRoleKey(label),
+        label,
+        family: 'support_partner',
+        operators: 0,
+        hasSupply: false,
+        source: 'fallback',
+    }));
+}
+
+function mapDirectoryRoleBrowseRow(row: any): DirectoryRoleBrowseOption | null {
+    const key = normalizeDirectoryRoleKey(row?.role_key ?? row?.slug ?? row?.role_slug ?? row?.role);
+    const label = String(row?.display_name ?? row?.role_label ?? row?.label ?? row?.name ?? '').trim() || humanizeDirectoryRole(key);
+
+    if (!key || !label) return null;
+
+    const operators = numberFromDirectoryRoleRow(row);
+    return {
+        key,
+        label,
+        family: String(row?.role_family ?? row?.family ?? row?.category ?? 'support_partner'),
+        operators,
+        hasSupply: Boolean(row?.has_supply ?? row?.has_entities ?? operators > 0),
+        source: 'supabase',
+    };
+}
+
+async function loadDirectoryRoleBrowseOptions(supabase: ReturnType<typeof createSupabaseServerClient>): Promise<DirectoryRoleBrowseOption[]> {
+    try {
+        const { data, error } = await supabase
+            .from('v_hc_directory_role_browse')
+            .select('*')
+            .limit(520);
+
+        if (error) {
+            console.warn('[directory] role browse view unavailable, using fallback role chips:', error.message);
+            return fallbackDirectoryRoleOptions();
+        }
+
+        const seen = new Set<string>();
+        const roles = (data ?? [])
+            .map(mapDirectoryRoleBrowseRow)
+            .filter((role): role is DirectoryRoleBrowseOption => Boolean(role))
+            .filter((role) => {
+                if (seen.has(role.key)) return false;
+                seen.add(role.key);
+                return true;
+            })
+            .sort((a, b) => {
+                if (a.hasSupply !== b.hasSupply) return Number(b.hasSupply) - Number(a.hasSupply);
+                if (a.operators !== b.operators) return b.operators - a.operators;
+                return a.label.localeCompare(b.label);
+            });
+
+        return roles.length > 0 ? roles : fallbackDirectoryRoleOptions();
+    } catch (error) {
+        console.warn('[directory] role browse exception, using fallback role chips:', error);
+        return fallbackDirectoryRoleOptions();
+    }
+}
 
 const countryTiers = [
     { title: 'Tier A Gold', codes: [['US','United States'],['CA','Canada'],['AU','Australia'],['GB','United Kingdom'],['NZ','New Zealand'],['ZA','South Africa'],['DE','Germany'],['NL','Netherlands'],['AE','United Arab Emirates'],['BR','Brazil']] },
@@ -180,7 +268,7 @@ const faqs = [
     },
 ];
 
-function buildDirectoryJsonLd(providerCount: number) {
+function buildDirectoryJsonLd(providerCount: number, roleLabels: string[]) {
     return {
         '@context': 'https://schema.org',
         '@graph': [
@@ -211,7 +299,7 @@ function buildDirectoryJsonLd(providerCount: number) {
                 name: 'Heavy Haul Support Directory',
                 description: 'Search Haul Command for pilot cars, escort vehicles, permit support, route survey help, infrastructure, and heavy haul support providers by location, service type, and proof state.',
                 isPartOf: { '@id': `${SITE_URL}/#website` },
-                about: roleCoverage,
+                about: roleLabels.length > 0 ? roleLabels : roleCoverage,
                 numberOfItems: providerCount,
             },
             {
@@ -259,15 +347,12 @@ export async function generateMetadata(): Promise<Metadata> {
 
 export default async function GlobalDirectory({ searchParams }: { searchParams: Promise<{ country?: string, q?: string, category?: string }> }) {
     const resolvedParams = await searchParams;
-    const cookieStore = await cookies();
-    const supabase = createServerClient(
-        process.env.NEXT_PUBLIC_SUPABASE_URL!,
-        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-        { cookies: { getAll: () => cookieStore.getAll(), setAll: () => {} } }
-    );
+    const supabase = createSupabaseServerClient();
     const targetCountry = normalizeDirectoryCountry(resolvedParams.country);
     const queryLocation = resolvedParams.q || '';
     const queryCategory = resolvedParams.category || '';
+    const roleBrowseOptions = await loadDirectoryRoleBrowseOptions(supabase);
+    const roleCoverageLabels = roleBrowseOptions.map((role) => role.label);
 
     let providers: any[] = [];
     let usedTypesense = false;
@@ -317,7 +402,7 @@ export default async function GlobalDirectory({ searchParams }: { searchParams: 
                 .select('*');
 
             if (plan.countryCode) {
-                query = query.eq('country_code_inferred', plan.countryCode);
+                query = query.eq('country_code', plan.countryCode);
             }
 
             const locationOrFilter = buildDirectoryLocationOrFilter(
@@ -348,7 +433,7 @@ export default async function GlobalDirectory({ searchParams }: { searchParams: 
             <script
                 type="application/ld+json"
                 suppressHydrationWarning
-                dangerouslySetInnerHTML={{ __html: JSON.stringify(buildDirectoryJsonLd(providers.length)) }}
+                dangerouslySetInnerHTML={{ __html: JSON.stringify(buildDirectoryJsonLd(providers.length, roleCoverageLabels.slice(0, 120))) }}
             />
             <div className="w-full bg-[#f8f9fa] border-b border-gray-200 py-12 px-4 shadow-sm">
                 <div className="max-w-7xl mx-auto">
@@ -429,16 +514,24 @@ export default async function GlobalDirectory({ searchParams }: { searchParams: 
                             </Link>
                         </div>
                         <div className="mt-6 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
-                            {roleCategoryLinks.map((role) => (
+                            {roleBrowseOptions.slice(0, 60).map((role) => (
                                 <Link
-                                    key={role.label}
-                                    href={`/directory?category=${encodeURIComponent(role.category)}&q=${encodeURIComponent(role.label)}`}
+                                    key={role.key}
+                                    href={`/directory?q=${encodeURIComponent(role.label)}`}
                                     className="rounded-xl border border-gray-200 bg-gray-50 px-3 py-3 text-sm font-bold text-gray-800 transition-colors hover:border-[#C6923A] hover:bg-amber-50"
                                 >
-                                    {role.label}
+                                    <span className="block">{role.label}</span>
+                                    <span className="mt-1 block text-[10px] font-black uppercase tracking-[0.08em] text-gray-500">
+                                        {role.hasSupply ? `${role.operators.toLocaleString()} records` : 'capture demand'}
+                                    </span>
                                 </Link>
                             ))}
                         </div>
+                        {roleBrowseOptions.length > 60 && (
+                            <p className="mt-4 text-xs font-bold text-gray-500">
+                                Showing the first 60 role surfaces from the live role registry. Use search to reach the full {roleBrowseOptions.length.toLocaleString()}-role catalog.
+                            </p>
+                        )}
                     </section>
 
                     <section aria-labelledby="country-coverage" className="rounded-2xl border border-gray-200 bg-white p-5 md:p-7 shadow-sm">


### PR DESCRIPTION
1. Summary
Hardens the public directory so live Supabase role catalog data drives the role chips/stats, directory source failures do not leak raw provider errors to users, legacy role-country URL shapes redirect into the working search surface instead of rendering wrong city pages, and the broken escort requirement calculator URL resolves to the current escort-count tool.

2. What was upgraded
- `app/directory/page.tsx`: reads `v_hc_directory_role_browse`, renders source-backed role counts, expands role chips beyond the hardcoded 12-item fallback, and masks raw data-source errors from public copy.
- `app/api/directory/search/route.ts`: continues across source failures and returns a safe incomplete-data flag instead of failing the whole search response on one broken source.
- `app/directory/[country]/[slug]/page.tsx`: detects legacy `/directory/{role}/{country}` requests and redirects them to the directory hub with country + role query state.
- `app/(public)/tools/escort-requirement-calculator/page.tsx`: redirects the broken legacy tool URL to `/tools/escort-count-calculator`.

3. Why it matters
This moves the public directory closer to the 120-country, 500-role Haul Command contract by making the live role registry the public browse source and avoiding false zero-market verdicts when one backend source is unavailable. It also removes a crawler-visible broken tool URL and stops role-country URLs from rendering misleading generic pilot-car city pages.

4. Verification
- `npm ci --legacy-peer-deps`: passed in clean worktree.
- `npm run typecheck`: passed.
- `npm run lint`: passed; this repo script aliases to the go-live typecheck.
- `npm test -- tests/unit/directory-query.test.ts tests/unit/directory-search-bar-filters.test.ts`: passed, 10 tests.
- `npm run build`: compiled successfully once, then failed collecting page data without env. After loading local env, build was blocked by a Windows `.next` artifact permission issue in the isolated worktree, not a TypeScript error.

5. Risk / rollback notes
- Public directory behavior changes from a fixed role-chip list to a Supabase-backed view with a safe fallback if the view is unavailable.
- Search API now returns partial results instead of hard 502 when one source fails; callers should read `data_issue` if they need to display incomplete-source state.
- The legacy role-country URL fix redirects to the hub rather than shipping a full role-country page implementation; the full canonical route contract still needs a dedicated follow-up.

6. Follow-up
- Build and deploy from CI/Vercel with production env to bypass the local `.next` permission issue.
- Implement canonical `/directory/{role}/{country}` and city pages backed by the same readiness gate before adding them to sitemap.
- Repair the public data-source/env issue causing live zero-record searches, then expose only source-backed ready pages in sitemap chunks.