### PR TITLE
[seo] Prefer coverage-backed role-country sitemap URLs

### DIFF
--- a/app/api/sitemap/route.ts
+++ b/app/api/sitemap/route.ts
@@ -103,15 +103,6 @@ function toHaulCommandUrl(pathOrUrl?: string | null) {
 }
 
 async function countRoleCountrySitemapUrls(supabase: SupabaseClient) {
-    const sitemapViewCount = await supabase
-        .from('v_hc_sitemap_eligible_pages' as never)
-        .select('page_url', { count: 'estimated', head: true })
-        .like('page_url', '/directory/%/%');
-
-    if (!sitemapViewCount.error) {
-        return sitemapViewCount.count ?? 0;
-    }
-
     const coverageCount = await supabase
         .from('hc_role_country_coverage')
         .select('page_url', { count: 'estimated', head: true })
@@ -129,19 +120,6 @@ async function fetchRoleCountrySitemapUrls(
 ) {
     if (endIndex < startIndex) return [];
 
-    const fromEligibleView = await supabase
-        .from('v_hc_sitemap_eligible_pages' as never)
-        .select('page_url, last_updated')
-        .like('page_url', '/directory/%/%')
-        .order('page_url', { ascending: true })
-        .range(startIndex, endIndex);
-
-    if (!fromEligibleView.error) {
-        return ((fromEligibleView.data ?? []) as SitemapPageRow[])
-            .map((row) => toHaulCommandUrl(row.page_url))
-            .filter((url): url is string => Boolean(url));
-    }
-
     const fromCoverage = await supabase
         .from('hc_role_country_coverage')
         .select('page_url, data_as_of')
@@ -150,9 +128,22 @@ async function fetchRoleCountrySitemapUrls(
         .order('page_url', { ascending: true })
         .range(startIndex, endIndex);
 
-    if (fromCoverage.error) return [];
+    if (!fromCoverage.error) {
+        return ((fromCoverage.data ?? []) as SitemapPageRow[])
+            .map((row) => toHaulCommandUrl(row.page_url))
+            .filter((url): url is string => Boolean(url));
+    }
 
-    return ((fromCoverage.data ?? []) as SitemapPageRow[])
+    const fromEligibleView = await supabase
+        .from('v_hc_sitemap_eligible_pages' as never)
+        .select('page_url, last_updated')
+        .like('page_url', '/directory/%/%')
+        .order('page_url', { ascending: true })
+        .range(startIndex, endIndex);
+
+    if (fromEligibleView.error) return [];
+
+    return ((fromEligibleView.data ?? []) as SitemapPageRow[])
         .map((row) => toHaulCommandUrl(row.page_url))
         .filter((url): url is string => Boolean(url));
 }


### PR DESCRIPTION
## Summary
Switch the role-country sitemap source of truth to `hc_role_country_coverage` `index_now` rows first, with `v_hc_sitemap_eligible_pages` only as fallback.

## What was upgraded
- `app/api/sitemap/route.ts`
  - Counts role-country sitemap URLs from `hc_role_country_coverage`.
  - Fetches role-country page URLs from coverage first so valid coverage rows are not dropped by freshness filters in the sitemap eligibility view.
  - Keeps the view fallback and valid XML behavior.

## Why it matters
PR #131 made role-country pages live, but production verification showed `/sitemap.xml?chunk=0` included some pilot-car role-country URLs while missing `/directory/us/pilot-car-operator`. Supabase audit found `v_hc_sitemap_eligible_pages` can exclude valid coverage rows when `data_as_of` lags `current_date`; coverage itself is the safer source for role-country sitemap discovery.

## Verification
- `npm run typecheck`
- `npm test -- tests/unit/directory-query.test.ts tests/unit/directory-search-bar-filters.test.ts tests/unit/directory-route-builders.test.ts`
- `git diff --check`
- Production checked after PR #131: `/directory/us/pilot-car-operator` renders the role-country page; `/directory/ae/pilot-car-operator` renders role-country; `/directory/us/tx` remains the Texas market page.

## Risk / rollback notes
- Sitemap generation only changes the role-country URL source; public route rendering is unchanged.
- If coverage query fails, the existing view fallback remains.
- Rollback is safe by reverting this PR.

## Follow-up
- After merge and production deploy, verify `/sitemap.xml?chunk=0` includes `/directory/us/pilot-car-operator` and remains valid XML.