### PR TITLE
[seo] Page role-country sitemap coverage URLs

### DIFF
--- a/app/api/sitemap/route.ts
+++ b/app/api/sitemap/route.ts
@@ -5,6 +5,7 @@ import { shouldIndexDirectoryOperator } from '@/lib/directory/operator-profile-s
 const MAX_URLS_PER_SITEMAP = 50000;
 const MAX_DYNAMIC_URLS_PER_SITEMAP = 45000;
 const MAX_CHUNK_ZERO_EXTRA_URLS = MAX_URLS_PER_SITEMAP - MAX_DYNAMIC_URLS_PER_SITEMAP;
+const SUPABASE_PAGE_SIZE = 1000;
 const BASE = 'https://www.haulcommand.com';
 
 const CANONICAL_STATIC_PATHS = [
@@ -120,30 +121,50 @@ async function fetchRoleCountrySitemapUrls(
 ) {
     if (endIndex < startIndex) return [];
 
-    const fromCoverage = await supabase
-        .from('hc_role_country_coverage')
-        .select('page_url, data_as_of')
-        .eq('index_verdict', 'index_now')
-        .not('page_url', 'is', null)
-        .order('page_url', { ascending: true })
-        .range(startIndex, endIndex);
+    const coverageRows: SitemapPageRow[] = [];
+    let coverageFailed = false;
+    for (let from = startIndex; from <= endIndex; from += SUPABASE_PAGE_SIZE) {
+        const to = Math.min(from + SUPABASE_PAGE_SIZE - 1, endIndex);
+        const { data, error } = await supabase
+            .from('hc_role_country_coverage')
+            .select('page_url, data_as_of')
+            .eq('index_verdict', 'index_now')
+            .not('page_url', 'is', null)
+            .order('page_url', { ascending: true })
+            .range(from, to);
 
-    if (!fromCoverage.error) {
-        return ((fromCoverage.data ?? []) as SitemapPageRow[])
+        if (error) {
+            coverageFailed = true;
+            break;
+        }
+
+        coverageRows.push(...((data ?? []) as SitemapPageRow[]));
+        if ((data?.length ?? 0) < to - from + 1) break;
+    }
+
+    if (!coverageFailed) {
+        return coverageRows
             .map((row) => toHaulCommandUrl(row.page_url))
             .filter((url): url is string => Boolean(url));
     }
 
-    const fromEligibleView = await supabase
-        .from('v_hc_sitemap_eligible_pages' as never)
-        .select('page_url, last_updated')
-        .like('page_url', '/directory/%/%')
-        .order('page_url', { ascending: true })
-        .range(startIndex, endIndex);
+    const viewRows: SitemapPageRow[] = [];
+    for (let from = startIndex; from <= endIndex; from += SUPABASE_PAGE_SIZE) {
+        const to = Math.min(from + SUPABASE_PAGE_SIZE - 1, endIndex);
+        const { data, error } = await supabase
+            .from('v_hc_sitemap_eligible_pages' as never)
+            .select('page_url, last_updated')
+            .like('page_url', '/directory/%/%')
+            .order('page_url', { ascending: true })
+            .range(from, to);
 
-    if (fromEligibleView.error) return [];
+        if (error) return [];
 
-    return ((fromEligibleView.data ?? []) as SitemapPageRow[])
+        viewRows.push(...((data ?? []) as SitemapPageRow[]));
+        if ((data?.length ?? 0) < to - from + 1) break;
+    }
+
+    return viewRows
         .map((row) => toHaulCommandUrl(row.page_url))
         .filter((url): url is string => Boolean(url));
 }


### PR DESCRIPTION
## Summary
Page through Supabase role-country coverage rows when building sitemap chunks so the sitemap includes all eligible role-country URLs, not just the first REST response slice.

## What was upgraded
- `app/api/sitemap/route.ts`
  - Adds a 1,000-row Supabase page size for role-country sitemap reads.
  - Iterates through `hc_role_country_coverage` ranges until the requested sitemap chunk slice is exhausted.
  - Keeps the `v_hc_sitemap_eligible_pages` fallback, also paged.

## Why it matters
Production verification after PR #132 showed `/sitemap.xml?chunk=0` was valid and included early alphabetic role-country URLs like AE, but still missed `/directory/us/pilot-car-operator`. The route was requesting a large range from Supabase REST; PostgREST caps returned rows, so later role-country URLs were not emitted. Paging the reads makes the 120-country directory sitemap complete.

## Verification
- `npm run typecheck`
- `npm test -- tests/unit/directory-query.test.ts tests/unit/directory-search-bar-filters.test.ts tests/unit/directory-route-builders.test.ts`
- `git diff --check`
- Production route verification before this PR: `/directory/us/pilot-car-operator` 200 role-country page, `/directory/ae/pilot-car-operator` 200 role-country page, `/directory/us/tx` remains Texas market page, directory search API returns `total=2255` for `pilot car` in US.

## Risk / rollback notes
- Sitemap generation may perform a few additional Supabase reads for large chunks, bounded at 1,000 rows per page and only for sitemap route requests.
- Public directory page rendering is unchanged.
- Rollback is safe by reverting this PR.

## Follow-up
- After merge and production deploy, verify `/sitemap.xml?chunk=0` includes both `/directory/ae/pilot-car-operator` and `/directory/us/pilot-car-operator`.