### PR TITLE
[fix] Recover directory state pages from live source tables

### DIFF
--- a/app/(public)/available-now/page.tsx
+++ b/app/(public)/available-now/page.tsx
@@ -8,6 +8,7 @@ import { LiveActivityFeed } from '@/components/feed/LiveActivityFeed';
 import { FreshnessBadge } from '@/components/ui/FreshnessBadge';
 import { AdGridSlot } from '@/components/home/AdGridSlot';
 import { stateFullName } from '@/lib/geo/state-names';
+import { isMissingOptionalSupabaseRelation } from '@/lib/supabase/optional-relations';
 
 // ===============================================================
 // /available-now — escort availability broadcast surface.
@@ -144,7 +145,11 @@ async function getAvailabilityData() {
     console.warn('[available-now] v_available_escorts query failed:', viewError.message);
   }
 
-  if (alertError && !alertError.message?.toLowerCase().includes('fetch failed')) {
+  if (
+    alertError &&
+    !alertError.message?.toLowerCase().includes('fetch failed') &&
+    !isMissingOptionalSupabaseRelation(alertError)
+  ) {
     console.warn('[available-now] supply_alerts query failed:', alertError.message);
   }
 

--- a/app/api/directory/search/route.ts
+++ b/app/api/directory/search/route.ts
@@ -6,6 +6,19 @@ import {
   resolveDirectorySearchAliases,
 } from '@/lib/directory/search-aliases';
 
+function cleanLocationPart(value: unknown) {
+  return String(value ?? '')
+    .trim()
+    .replace(/\s+/g, ' ')
+    .replace(/\s*,\s*[A-Z]{2}\s*$/i, '');
+}
+
+function formatDirectoryLocation(city: unknown, region: unknown) {
+  const cleanCity = cleanLocationPart(city);
+  const cleanRegion = String(region ?? '').trim().toUpperCase();
+  return [cleanCity, cleanRegion].filter(Boolean).join(', ');
+}
+
 /**
  * GET /api/directory/search
  *
@@ -72,7 +85,7 @@ export async function GET(req: NextRequest) {
               name: doc.company_name || doc.display_name || 'Operator',
               city: doc.city,
               state: doc.state || doc.state_province,
-              location: `${doc.city || ''}, ${doc.state || doc.state_province || ''}`,
+              location: formatDirectoryLocation(doc.city, doc.state || doc.state_province),
               region_code: doc.state || doc.state_province,
               country_code: doc.country || doc.country_code,
               services: doc.service_categories || [],
@@ -183,7 +196,7 @@ export async function GET(req: NextRequest) {
       name: row.name || 'Service Business',
       city: row.locality,
       state: row.admin1_code,
-      location: `${row.locality}, ${row.admin1_code}`,
+      location: formatDirectoryLocation(row.locality, row.admin1_code),
       region_code: row.admin1_code,
       country_code: row.country_code,
       services: [row.surface_category_key].filter(Boolean),
@@ -268,7 +281,7 @@ export async function GET(req: NextRequest) {
           name: op.name || 'Escort Operator',
           city: op.city,
           state: op.admin1_code,
-          location: `${op.city}, ${op.admin1_code}`,
+          location: formatDirectoryLocation(op.city, op.admin1_code),
           region_code: op.admin1_code,
           country_code: op.country_code,
           services: op.role_primary ? [op.role_primary] : [],

--- a/app/api/sponsor/pricing/route.ts
+++ b/app/api/sponsor/pricing/route.ts
@@ -12,6 +12,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { getSupabaseAdmin } from '@/lib/supabase/admin';
+import { isMissingOptionalSupabaseRelation } from '@/lib/supabase/optional-relations';
 
 export const dynamic = 'force-dynamic';
 
@@ -157,7 +158,7 @@ export async function GET(req: NextRequest) {
         }
     }
 
-    const { data: alerts } = await supabase
+    const { data: alerts, error: alertsError } = await supabase
         .from('supply_alerts')
         .select('id,city,state_code,corridor_id,alert_type,available_count,message,expires_at')
         .eq('active', true)
@@ -165,7 +166,9 @@ export async function GET(req: NextRequest) {
         .limit(12);
 
     const normalizedValue = (value || h3Cell).toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
-    supplyAlerts = (alerts ?? [])
+    const marketAlerts = alertsError && isMissingOptionalSupabaseRelation(alertsError) ? [] : (alerts ?? []);
+
+    supplyAlerts = marketAlerts
         .filter((alert: any) => {
             const expiresAt = alert.expires_at ? new Date(alert.expires_at).getTime() : null;
             if (expiresAt && expiresAt <= Date.now()) return false;

--- a/app/api/v1/demand-intelligence/supply-alerts/route.ts
+++ b/app/api/v1/demand-intelligence/supply-alerts/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase/admin";
+import { isMissingOptionalSupabaseRelation } from "@/lib/supabase/optional-relations";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -42,12 +43,14 @@ export async function GET(req: Request) {
   const { data, error } = await query;
 
   if (error) {
+    const sourceStatus = isMissingOptionalSupabaseRelation(error) ? "not_configured" : "unavailable";
+
     return NextResponse.json(
       {
         ok: false,
         alerts_count: 0,
         alerts: [],
-        source_status: "unavailable",
+        source_status: sourceStatus,
       },
       { headers: { "Cache-Control": "public, max-age=60, stale-while-revalidate=120" } },
     );

--- a/app/directory/[country]/[slug]/page.tsx
+++ b/app/directory/[country]/[slug]/page.tsx
@@ -71,6 +71,14 @@ function rankDirectoryRecord(record: any) {
   return Number(record.rank_score ?? record.confidence_score ?? record.directory_quality_score ?? 0);
 }
 
+function normalizeRegionCode(value: unknown) {
+  return String(value ?? '').trim().toUpperCase();
+}
+
+function normalizeMarketText(value: unknown) {
+  return String(value ?? '').trim().toLowerCase();
+}
+
 function displayRoleFromSlug(slug: string) {
   return String(slug ?? '')
     .replace(/[_-]+/g, ' ')
@@ -416,6 +424,153 @@ async function fetchDirectoryMarketRecords(
   };
 }
 
+function applyMarketScopeToHcPlacesQuery(query: any, plan: DirectoryMarketFilterPlan) {
+  if (plan.scope.type === 'region') {
+    return query.eq('admin1_code', plan.scope.code);
+  }
+
+  const marketName = plan.scope.name;
+  return query.or(`locality.ilike.%${marketName}%,admin2_name.ilike.%${marketName}%,name.ilike.%${marketName}%`);
+}
+
+function applyMarketScopeToGlobalOperatorsQuery(query: any, plan: DirectoryMarketFilterPlan) {
+  if (plan.scope.type === 'region') {
+    return query.eq('admin1_code', plan.scope.code);
+  }
+
+  const marketName = plan.scope.name;
+  return query.or(`city.ilike.%${marketName}%,service_area.ilike.%${marketName}%,name.ilike.%${marketName}%`);
+}
+
+function mapHcPlaceMarketRecord(row: any) {
+  return {
+    id: row.id,
+    contact_id: row.id,
+    name: row.name,
+    company: row.name,
+    slug: row.slug,
+    city: row.locality,
+    city_inferred: row.locality,
+    admin1_code: row.admin1_code,
+    state: row.admin1_code,
+    country_code: row.country_code,
+    lat: row.lat,
+    lon: row.lng,
+    website: row.website,
+    phone_raw: row.phone,
+    entity_family: 'support_place',
+    entity_subtype: row.surface_category_key,
+    role_primary: row.surface_category_key,
+    claim_status: row.claim_status,
+    verification_status: row.hc_verified ? 'verified' : null,
+    confidence_score: row.source_confidence ?? row.demand_score ?? 0,
+    rank_score: row.demand_score ?? row.source_confidence ?? 0,
+    profile_url: row.slug ? `/directory/dossier/${row.id}` : null,
+    source_view: 'hc_places',
+  };
+}
+
+function mapGlobalOperatorMarketRecord(row: any) {
+  return {
+    id: row.id,
+    contact_id: row.id,
+    name: row.name,
+    company: row.business_name || row.name,
+    slug: row.slug,
+    city: row.city,
+    city_inferred: row.city,
+    admin1_code: row.admin1_code,
+    state: row.admin1_code,
+    country_code: row.country_code,
+    lat: row.lat,
+    lon: row.lng,
+    phone_raw: row.phone_normalized,
+    email: row.email,
+    website: row.website_url,
+    entity_family: row.entity_family || 'operator',
+    entity_subtype: row.role_primary,
+    role_primary: row.role_primary,
+    claim_status: row.claim_status ?? (row.is_claimed ? 'claimed' : null),
+    verification_status: row.verification_status ?? (row.is_verified ? 'verified' : null),
+    confidence_score: row.confidence_score ?? row.trust_score ?? 0,
+    rank_score: row.trust_score ?? row.confidence_score ?? 0,
+    profile_url: row.slug ? `/directory/dossier/${row.id}` : null,
+    source_view: 'hc_global_operators',
+  };
+}
+
+async function fetchDirectoryMarketSourceFallback(
+  supabase: ReturnType<typeof createClient>,
+  plan: DirectoryMarketFilterPlan,
+  countryUpper: string,
+) {
+  const sourceLimit = Math.max(12, Math.ceil(plan.limit / 2));
+
+  let placesQuery = supabase
+    .from('hc_places')
+    .select('id,name,slug,surface_category_key,country_code,admin1_code,admin2_name,locality,lat,lng,phone,website,source_confidence,status,is_search_indexable,claim_status,demand_score,hc_verified', { count: 'exact' })
+    .eq('status', 'published')
+    .eq('is_search_indexable', true)
+    .eq('country_code', countryUpper)
+    .or('name.ilike.%pilot%,name.ilike.%escort%,surface_category_key.ilike.%pilot%,surface_category_key.ilike.%escort%')
+    .order('demand_score', { ascending: false, nullsFirst: false })
+    .limit(sourceLimit);
+
+  placesQuery = applyMarketScopeToHcPlacesQuery(placesQuery, plan);
+
+  let operatorsQuery = supabase
+    .from('hc_global_operators')
+    .select('id,name,business_name,slug,country_code,admin1_code,city,phone_normalized,email,website_url,is_claimed,is_verified,role_primary,confidence_score,trust_score,claim_status,verification_status,entity_family,lat,lng,service_area', { count: 'exact' })
+    .eq('country_code', countryUpper)
+    .not('admin1_code', 'is', null)
+    .not('city', 'is', null)
+    .or('name.ilike.%pilot%,name.ilike.%escort%,business_name.ilike.%pilot%,business_name.ilike.%escort%,role_primary.ilike.%pilot%,role_primary.ilike.%escort%')
+    .order('confidence_score', { ascending: false, nullsFirst: false })
+    .limit(sourceLimit);
+
+  operatorsQuery = applyMarketScopeToGlobalOperatorsQuery(operatorsQuery, plan);
+
+  const [placesResult, operatorsResult] = await Promise.all([placesQuery, operatorsQuery]);
+
+  if (placesResult.error) {
+    console.warn(`[directory-city] hc_places fallback failed for ${countryUpper}/${plan.marketName}:`, placesResult.error.message);
+  }
+  if (operatorsResult.error) {
+    console.warn(`[directory-city] hc_global_operators fallback failed for ${countryUpper}/${plan.marketName}:`, operatorsResult.error.message);
+  }
+
+  const seen = new Set<string>();
+  const records = [
+    ...((placesResult.data ?? []) as any[]).map(mapHcPlaceMarketRecord),
+    ...((operatorsResult.data ?? []) as any[]).map(mapGlobalOperatorMarketRecord),
+  ]
+    .filter((record) => {
+      const id = recordId(record);
+      if (!id || seen.has(id)) return false;
+      seen.add(id);
+      return true;
+    })
+    .filter((record) => {
+      if (plan.scope.type === 'region') {
+        return normalizeRegionCode(record.admin1_code || record.state) === plan.scope.code;
+      }
+      const market = normalizeMarketText(plan.scope.name);
+      return [
+        record.city,
+        record.city_inferred,
+        record.company,
+        record.name,
+      ].some((value) => normalizeMarketText(value).includes(market));
+    })
+    .sort((a: any, b: any) => rankDirectoryRecord(b) - rankDirectoryRecord(a))
+    .slice(0, plan.limit);
+
+  return {
+    records,
+    totalCount: (placesResult.count ?? 0) + (operatorsResult.count ?? 0),
+  };
+}
+
 async function RoleCountryDirectoryPage({
   country,
   slug,
@@ -702,7 +857,11 @@ export async function generateMetadata({ params }: PageProps) {
   const countryUpper = plan.countryCode ?? country.toUpperCase();
   const marketName = plan.marketName;
   const supabase = createClient();
-  const count = await countDirectoryMarketRecords(supabase, plan, countryUpper);
+  let count = await countDirectoryMarketRecords(supabase, plan, countryUpper);
+  if (count === 0) {
+    const fallback = await fetchDirectoryMarketSourceFallback(supabase, plan, countryUpper);
+    count = fallback.totalCount || fallback.records.length;
+  }
 
   return contractToMetadata(buildDirectoryMarketSeoContract({
     countryCode: countryUpper,
@@ -770,7 +929,12 @@ export default async function CityDirectoryPage({ params }: PageProps) {
   const marketKind = plan.scope.type === 'region' ? 'region' : plan.scope.type === 'metro' ? 'metro' : 'city';
 
   // Fetch public directory records in this market through the directory surface facade.
-  const { records: ops, totalCount } = await fetchDirectoryMarketRecords(supabase, plan, countryUpper);
+  let { records: ops, totalCount } = await fetchDirectoryMarketRecords(supabase, plan, countryUpper);
+  if (totalCount === 0) {
+    const fallback = await fetchDirectoryMarketSourceFallback(supabase, plan, countryUpper);
+    ops = fallback.records;
+    totalCount = fallback.totalCount;
+  }
   const opCount = totalCount || ops.length;
 
   // If absolutely no operators found, still render the page (SEO value)

--- a/app/directory/page.tsx
+++ b/app/directory/page.tsx
@@ -152,6 +152,57 @@ function mapDirectoryRoleBrowseRow(row: any): DirectoryRoleBrowseOption | null {
     };
 }
 
+function mapHcPlaceHomepageProvider(row: any) {
+    return {
+        id: row.id,
+        contact_id: row.id,
+        name: row.name,
+        company: row.name,
+        slug: row.slug,
+        city: row.locality,
+        city_inferred: row.locality,
+        state: row.admin1_code,
+        state_inferred: row.admin1_code,
+        country_code: row.country_code,
+        phone_raw: row.phone,
+        website: row.website,
+        entity_family: 'support_place',
+        entity_subtype: row.surface_category_key,
+        role_primary: row.surface_category_key,
+        claim_status: row.claim_status,
+        verification_status: row.hc_verified ? 'verified' : null,
+        confidence_score: row.source_confidence ?? row.demand_score ?? 0,
+        rank_score: row.demand_score ?? row.source_confidence ?? 0,
+        source: 'hc_places',
+    };
+}
+
+function mapGlobalOperatorHomepageProvider(row: any) {
+    return {
+        id: row.id,
+        contact_id: row.id,
+        name: row.name,
+        company: row.business_name || row.name,
+        slug: row.slug,
+        city: row.city,
+        city_inferred: row.city,
+        state: row.admin1_code,
+        state_inferred: row.admin1_code,
+        country_code: row.country_code,
+        phone_raw: row.phone_normalized,
+        email: row.email,
+        website: row.website_url,
+        entity_family: row.entity_family || 'operator',
+        entity_subtype: row.role_primary,
+        role_primary: row.role_primary,
+        claim_status: row.claim_status ?? (row.is_claimed ? 'claimed' : null),
+        verification_status: row.verification_status ?? (row.is_verified ? 'verified' : null),
+        confidence_score: row.confidence_score ?? row.trust_score ?? 0,
+        rank_score: row.trust_score ?? row.confidence_score ?? 0,
+        source: 'hc_global_operators',
+    };
+}
+
 async function loadDirectoryRoleBrowseOptions(supabase: ReturnType<typeof createSupabaseServerClient>): Promise<DirectoryRoleBrowseOption[]> {
     try {
         const { data, error } = await supabase
@@ -184,6 +235,52 @@ async function loadDirectoryRoleBrowseOptions(supabase: ReturnType<typeof create
         console.warn('[directory] role browse exception, using fallback role chips:', error);
         return fallbackDirectoryRoleOptions();
     }
+}
+
+async function loadDirectoryHomepageFallbackProviders(
+    supabase: ReturnType<typeof createSupabaseServerClient>,
+    targetCountry: string | null,
+) {
+    const placesQuery = supabase
+        .from('hc_places')
+        .select('id,name,slug,surface_category_key,country_code,admin1_code,locality,phone,website,source_confidence,status,is_search_indexable,claim_status,demand_score,hc_verified')
+        .eq('status', 'published')
+        .eq('is_search_indexable', true)
+        .order('demand_score', { ascending: false, nullsFirst: false })
+        .limit(36);
+
+    const operatorsQuery = supabase
+        .from('hc_global_operators')
+        .select('id,name,business_name,slug,country_code,admin1_code,city,phone_normalized,email,website_url,is_claimed,is_verified,role_primary,confidence_score,trust_score,claim_status,verification_status,entity_family')
+        .not('admin1_code', 'is', null)
+        .not('city', 'is', null)
+        .order('confidence_score', { ascending: false, nullsFirst: false })
+        .limit(24);
+
+    const scopedPlacesQuery = targetCountry ? placesQuery.eq('country_code', targetCountry) : placesQuery;
+    const scopedOperatorsQuery = targetCountry ? operatorsQuery.eq('country_code', targetCountry) : operatorsQuery;
+    const [placesResult, operatorsResult] = await Promise.all([scopedPlacesQuery, scopedOperatorsQuery]);
+
+    if (placesResult.error) {
+        console.warn('[directory] hc_places homepage fallback failed:', placesResult.error.message);
+    }
+    if (operatorsResult.error) {
+        console.warn('[directory] hc_global_operators homepage fallback failed:', operatorsResult.error.message);
+    }
+
+    const seen = new Set<string>();
+    return [
+        ...((placesResult.data ?? []) as any[]).map(mapHcPlaceHomepageProvider),
+        ...((operatorsResult.data ?? []) as any[]).map(mapGlobalOperatorHomepageProvider),
+    ]
+        .filter((record) => {
+            const id = String(record.contact_id || record.id || record.slug || record.name || '').trim();
+            if (!id || seen.has(id)) return false;
+            seen.add(id);
+            return true;
+        })
+        .sort((a, b) => Number(b.rank_score ?? 0) - Number(a.rank_score ?? 0))
+        .slice(0, 50);
 }
 
 const countryTiers = [
@@ -426,6 +523,10 @@ export default async function GlobalDirectory({ searchParams }: { searchParams: 
         } catch (e) {
             console.warn('[directory] Supabase query failed:', e);
         }
+    }
+
+    if (providers.length === 0) {
+        providers = await loadDirectoryHomepageFallbackProviders(supabase, targetCountry);
     }
 
     return (

--- a/lib/supabase/optional-relations.ts
+++ b/lib/supabase/optional-relations.ts
@@ -1,0 +1,22 @@
+const MISSING_RELATION_PATTERNS = [
+  'could not find the table',
+  'could not find table',
+  'does not exist',
+  'schema cache',
+  'relation',
+];
+
+export function isMissingOptionalSupabaseRelation(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+
+  const candidate = error as { code?: unknown; message?: unknown; details?: unknown; hint?: unknown };
+  const code = typeof candidate.code === 'string' ? candidate.code.toUpperCase() : '';
+  if (code === 'PGRST205' || code === 'PGRST202' || code === '42P01') return true;
+
+  const text = [candidate.message, candidate.details, candidate.hint]
+    .filter((value): value is string => typeof value === 'string')
+    .join(' ')
+    .toLowerCase();
+
+  return MISSING_RELATION_PATTERNS.some((pattern) => text.includes(pattern));
+}

--- a/supabase/migrations/20260529150955_supply_alerts_compatibility.sql
+++ b/supabase/migrations/20260529150955_supply_alerts_compatibility.sql
@@ -1,0 +1,43 @@
+create table if not exists public.supply_alerts (
+  id uuid primary key default gen_random_uuid(),
+  city text,
+  state_code text,
+  corridor_id text,
+  alert_type text,
+  available_count integer,
+  demand_rate numeric,
+  message text not null default 'Active supply pressure signal for this market.',
+  active boolean not null default true,
+  expires_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+comment on table public.supply_alerts is
+  'Optional market-pressure alerts consumed by available-now and sponsor pricing. Public reads are limited to active, unexpired alerts.';
+
+create index if not exists idx_supply_alerts_active_recent
+  on public.supply_alerts (active, created_at desc);
+
+create index if not exists idx_supply_alerts_state_active
+  on public.supply_alerts (state_code, active, created_at desc)
+  where state_code is not null;
+
+create index if not exists idx_supply_alerts_corridor_active
+  on public.supply_alerts (corridor_id, active, created_at desc)
+  where corridor_id is not null;
+
+alter table public.supply_alerts enable row level security;
+
+drop policy if exists "Public can read active unexpired supply alerts" on public.supply_alerts;
+create policy "Public can read active unexpired supply alerts"
+  on public.supply_alerts
+  for select
+  to anon, authenticated
+  using (
+    active = true
+    and (expires_at is null or expires_at > now())
+  );
+
+grant select on public.supply_alerts to anon, authenticated;
+grant all on public.supply_alerts to service_role;


### PR DESCRIPTION
1. Summary
Recover public directory state/region pages when facade views return no records by falling back to the same source-backed tables used by directory search. Also harden optional supply-alert reads and mirror the live supply_alerts compatibility table in migrations.

2. What was upgraded
- app/directory/[country]/[slug]/page.tsx
- app/directory/page.tsx
- app/api/directory/search/route.ts
- app/(public)/available-now/page.tsx
- app/api/sponsor/pricing/route.ts
- app/api/v1/demand-intelligence/supply-alerts/route.ts
- lib/supabase/optional-relations.ts
- supabase/migrations/20260529150955_supply_alerts_compatibility.sql

3. Why it matters
Texas and other state directory pages were showing zero records even when live source-backed records existed in hc_places and hc_global_operators. This keeps Haul Command directory pages useful, honest, and promotable while preserving no-fake-supply rules. The supply_alerts compatibility path removes a noisy production health gap without inventing alerts.

4. Verification
- npm run typecheck
- npm test -- tests/unit/directory-query.test.ts tests/unit/directory-search-bar-filters.test.ts tests/unit/directory-route-builders.test.ts
- git diff --check
- npm run build compiled successfully, then local page-data collection failed because local Supabase env was not present: supabaseUrl is required for /api/batch/generate-seo. This is an existing local-env blocker; Vercel has production env configured.
- Live Supabase migration supply_alerts_compatibility applied to hvjyfyzotqobfkakjozp and RLS policy verified.

5. Risk / rollback notes
Public state pages may now show source-backed hc_places/hc_global_operators fallback records when facade views are empty. The fallback is bounded to published/search-indexable places and operator records with country/region/city context. supply_alerts public RLS only exposes active unexpired rows.

6. Follow-up
Wire v_hc_supply_gap_grid and hc_supply_acquisition_queue into admin health and worker/cron execution so no-supply role-country cells become actionable.