### PR TITLE
[fix] Unlock market directory pages from source records

### DIFF
--- a/app/directory/[country]/[slug]/page.tsx
+++ b/app/directory/[country]/[slug]/page.tsx
@@ -512,7 +512,6 @@ async function fetchDirectoryMarketSourceFallback(
     .eq('status', 'published')
     .eq('is_search_indexable', true)
     .eq('country_code', countryUpper)
-    .or('name.ilike.%pilot%,name.ilike.%escort%,surface_category_key.ilike.%pilot%,surface_category_key.ilike.%escort%')
     .order('demand_score', { ascending: false, nullsFirst: false })
     .limit(sourceLimit);
 
@@ -524,7 +523,6 @@ async function fetchDirectoryMarketSourceFallback(
     .eq('country_code', countryUpper)
     .not('admin1_code', 'is', null)
     .not('city', 'is', null)
-    .or('name.ilike.%pilot%,name.ilike.%escort%,business_name.ilike.%pilot%,business_name.ilike.%escort%,role_primary.ilike.%pilot%,role_primary.ilike.%escort%')
     .order('confidence_score', { ascending: false, nullsFirst: false })
     .limit(sourceLimit);
 

--- a/lib/directory/search-aliases.ts
+++ b/lib/directory/search-aliases.ts
@@ -16,7 +16,7 @@ export function normalizeDirectoryAliasQuery(value: string): string {
 }
 
 function cleanPostgrestTerm(value: string): string {
-  return value.trim().replace(/[%,()]/g, " ").replace(/\s+/g, " ");
+  return value.trim().replace(/[%,()]/g, " ").replace(/\s+/g, "%");
 }
 
 function cleanPostgrestEquality(value: string): string {

--- a/tests/unit/directory-search-aliases.test.ts
+++ b/tests/unit/directory-search-aliases.test.ts
@@ -25,7 +25,7 @@ describe("directory search aliases", () => {
 
   it("adds canonical role/category terms without losing the user query", () => {
     expect(getAliasAwareSearchTerms("rest area", [restAreaAlias])).toEqual([
-      "rest area",
+      "rest%area",
       "rest_area",
     ]);
     expect(getAliasCanonicalTargets([restAreaAlias])).toEqual(["rest_area"]);
@@ -37,7 +37,7 @@ describe("directory search aliases", () => {
         restAreaAlias,
       ]),
     ).toBe(
-      "name.ilike.%rest area%,name.ilike.%rest_area%,locality.ilike.%rest area%,locality.ilike.%rest_area%,surface_category_key.eq.rest_area",
+      "name.ilike.%rest%area%,name.ilike.%rest_area%,locality.ilike.%rest%area%,locality.ilike.%rest_area%,surface_category_key.eq.rest_area",
     );
   });
 });


### PR DESCRIPTION
## Summary
Fixes the remaining live directory gap where state/region pages could still render as empty even when source-backed market records exist. It also fixes multi-word directory searches like `pilot car` by making alias-aware PostgREST filters wildcard-safe.

## What was upgraded
- `app/directory/[country]/[slug]/page.tsx`
  - Broadened the market-page source fallback to render the whole source-backed heavy-haul support ecosystem for a market from `hc_places` and `hc_global_operators` instead of only pilot/escort keyword matches.
- `lib/directory/search-aliases.ts`
  - Converts multi-word alias/search terms into PostgREST-safe wildcard terms such as `pilot%car`.
- `tests/unit/directory-search-aliases.test.ts`
  - Updated coverage for the wildcard-safe filter behavior.

## Why it matters
This clears the visible public-directory blocker where a market like Texas can have live Supabase records but still show a sparse/no-support state. It also preserves Haul Command's broader ecosystem model: places, providers, infrastructure, and services are all valid directory assets because humans operate the work behind them.

## Verification
- `npm test -- tests/unit/directory-search-aliases.test.ts tests/unit/directory-query.test.ts tests/unit/directory-search-bar-filters.test.ts tests/unit/directory-route-builders.test.ts` passed: 16 tests.
- `npm run typecheck` passed.
- `git diff --check` passed.
- `npm run build` compiled successfully, then failed during page-data collection because the local shell lacks Supabase env for `/api/batch/generate-seo` (`supabaseUrl is required`). This is the same local-env blocker seen before and not caused by this patch.

## Risk / rollback notes
- Public market pages will now show broader source-backed support records when facade views are empty. This is intentional for ecosystem coverage but should be monitored for page copy alignment.
- No database migrations or RLS changes in this PR.
- Roll back by reverting this commit if market pages need to return to pilot/escort-only fallback behavior.

## Follow-up
- Verify production `/directory/us/tx`, `/directory`, and `/api/directory/search?q=pilot%20car&country=US&state=TX` after Vercel deploys this PR.
- Next blocker: bridge `hc_supply_acquisition_queue` / `v_hc_supply_gap_grid` into cron/admin/worker execution so the 49k no-supply cells become drainable work, not just database rows.