### PR TITLE
[worker] Bridge supply acquisition queue into cron tasks

### DIFF
--- a/app/api/cron/listing-rescue/route.ts
+++ b/app/api/cron/listing-rescue/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireInternalRequest } from "@/lib/security/internal-request-auth";
+import { queueSupplyAcquisitionTasks } from "@/lib/directory/supply-acquisition-queue";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 300;
+
+export async function POST(req: NextRequest) {
+  const authFailure = requireInternalRequest(req);
+  if (authFailure) return authFailure;
+
+  try {
+    const body = await req.json().catch(() => ({}));
+    const result = await queueSupplyAcquisitionTasks({
+      limit: body.limit ?? 100,
+      dryRun: body.dry_run === true,
+      queueStates: ["ready", "pending", "open", "queued"],
+    });
+
+    return NextResponse.json({
+      ok: true,
+      workflow: "listing_rescue_supply_acquisition_bridge",
+      ...result,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown listing-rescue cron error";
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}
+
+export async function GET(req: NextRequest) {
+  return POST(req);
+}

--- a/app/api/cron/partner-hunt/route.ts
+++ b/app/api/cron/partner-hunt/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireInternalRequest } from "@/lib/security/internal-request-auth";
+import { queueSupplyAcquisitionTasks } from "@/lib/directory/supply-acquisition-queue";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 300;
+
+export async function POST(req: NextRequest) {
+  const authFailure = requireInternalRequest(req);
+  if (authFailure) return authFailure;
+
+  try {
+    const body = await req.json().catch(() => ({}));
+    const result = await queueSupplyAcquisitionTasks({
+      limit: body.limit ?? 75,
+      dryRun: body.dry_run === true,
+      queueStates: ["ready", "pending", "open"],
+    });
+
+    return NextResponse.json({
+      ok: true,
+      workflow: "partner_hunt_supply_acquisition_bridge",
+      ...result,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown partner-hunt cron error";
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}
+
+export async function GET(req: NextRequest) {
+  return POST(req);
+}

--- a/app/api/cron/supply-density/route.ts
+++ b/app/api/cron/supply-density/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireInternalRequest } from "@/lib/security/internal-request-auth";
+import {
+  getSupplyAcquisitionQueueSummary,
+  queueSupplyAcquisitionTasks,
+} from "@/lib/directory/supply-acquisition-queue";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 300;
+
+async function run(req: NextRequest) {
+  const authFailure = requireInternalRequest(req);
+  if (authFailure) return authFailure;
+
+  const body = await req.json().catch(() => ({}));
+  const result = await queueSupplyAcquisitionTasks({
+    limit: body.limit,
+    dryRun: body.dry_run === true,
+  });
+
+  return NextResponse.json({
+    ok: true,
+    workflow: "supply_density_to_acquisition_tasks",
+    ...result,
+  });
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    return await run(req);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown supply-density cron error";
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}
+
+export async function GET(req: NextRequest) {
+  const authFailure = requireInternalRequest(req);
+  if (authFailure) return authFailure;
+
+  try {
+    const summary = await getSupplyAcquisitionQueueSummary();
+    return NextResponse.json({
+      ok: true,
+      workflow: "supply_density_to_acquisition_tasks",
+      summary,
+      trigger: "POST with optional { limit, dry_run } to queue work",
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown supply-density health error";
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}

--- a/lib/directory/supply-acquisition-queue.ts
+++ b/lib/directory/supply-acquisition-queue.ts
@@ -1,0 +1,163 @@
+import { getSupabaseAdmin } from "@/lib/supabase/admin";
+
+export type QueueSupplyAcquisitionOptions = {
+  limit?: number;
+  dryRun?: boolean;
+  queueStates?: string[];
+};
+
+type SupplyAcquisitionRow = {
+  id: string;
+  country_code: string;
+  role_key: string;
+  tier: string | null;
+  current_operators: number | null;
+  target_operators: number | null;
+  supply_state: string | null;
+  priority: number | null;
+  hunt_status: string | null;
+  planned_source_name: string | null;
+  planned_source_url: string | null;
+  planned_source_method: string | null;
+  planned_priority_tier: string | null;
+  planned_entity_estimate: number | null;
+  monetization_impact: string | null;
+};
+
+const DEFAULT_READY_STATES = ["queued", "ready", "pending", "open"];
+const CLOSED_STATES = new Set(["in_progress", "completed", "failed", "blocked", "dismissed"]);
+
+function normalizeLimit(limit: number | undefined) {
+  if (!Number.isFinite(limit ?? 0)) return 50;
+  return Math.max(1, Math.min(Math.trunc(limit ?? 50), 250));
+}
+
+function isQueueable(row: SupplyAcquisitionRow, readyStates: string[]) {
+  const status = String(row.hunt_status ?? "").trim().toLowerCase();
+  if (!status) return true;
+  if (CLOSED_STATES.has(status)) return false;
+  return readyStates.includes(status);
+}
+
+function buildSupplyTaskPayload(row: SupplyAcquisitionRow) {
+  return {
+    supply_queue_id: row.id,
+    country_code: row.country_code,
+    role_key: row.role_key,
+    tier: row.tier,
+    current_operators: row.current_operators ?? 0,
+    target_operators: row.target_operators ?? 0,
+    supply_state: row.supply_state,
+    planned_source_name: row.planned_source_name,
+    planned_source_url: row.planned_source_url,
+    planned_source_method: row.planned_source_method,
+    planned_priority_tier: row.planned_priority_tier,
+    planned_entity_estimate: row.planned_entity_estimate,
+    monetization_impact: row.monetization_impact,
+  };
+}
+
+export async function queueSupplyAcquisitionTasks(options: QueueSupplyAcquisitionOptions = {}) {
+  const supabase = getSupabaseAdmin();
+  const limit = normalizeLimit(options.limit);
+  const readyStates = (options.queueStates?.length ? options.queueStates : DEFAULT_READY_STATES)
+    .map((state) => state.trim().toLowerCase())
+    .filter(Boolean);
+
+  const { data, error } = await supabase
+    .from("hc_supply_acquisition_queue")
+    .select(
+      "id,country_code,role_key,tier,current_operators,target_operators,supply_state,priority,hunt_status,planned_source_name,planned_source_url,planned_source_method,planned_priority_tier,planned_entity_estimate,monetization_impact",
+    )
+    .order("priority", { ascending: false, nullsFirst: false })
+    .order("created_at", { ascending: true })
+    .limit(limit * 3);
+
+  if (error) {
+    throw new Error(`Failed to read hc_supply_acquisition_queue: ${error.message}`);
+  }
+
+  const candidates = ((data ?? []) as SupplyAcquisitionRow[])
+    .filter((row) => isQueueable(row, readyStates))
+    .slice(0, limit);
+
+  if (options.dryRun || candidates.length === 0) {
+    return {
+      ok: true,
+      dryRun: Boolean(options.dryRun),
+      candidates: candidates.length,
+      tasksCreated: 0,
+      queuedIds: candidates.map((row) => row.id),
+    };
+  }
+
+  const taskRows = candidates.map((row) => ({
+    title: `Acquire ${row.role_key.replace(/_/g, " ")} supply in ${row.country_code}`,
+    description: `Create source-backed directory supply for ${row.role_key} in ${row.country_code}. Current operators: ${row.current_operators ?? 0}; target: ${row.target_operators ?? 0}.`,
+    status: "pending",
+    priority: row.priority ?? 50,
+    domain: "directory",
+    market: row.country_code,
+    target_entity_type: "role_country_supply",
+    requires_proof: true,
+    task_type: "supply.acquire",
+    agent_slug: "supply-acquisition-worker",
+    payload: buildSupplyTaskPayload(row),
+    country_code: row.country_code,
+    max_attempts: 3,
+    run_after: new Date().toISOString(),
+  }));
+
+  const { data: inserted, error: insertError } = await supabase
+    .from("hc_command_tasks")
+    .insert(taskRows)
+    .select("id");
+
+  if (insertError) {
+    throw new Error(`Failed to create supply acquisition command tasks: ${insertError.message}`);
+  }
+
+  const queuedIds = candidates.map((row) => row.id);
+  const { error: updateError } = await supabase
+    .from("hc_supply_acquisition_queue")
+    .update({ hunt_status: "queued", last_hunted_at: new Date().toISOString() })
+    .in("id", queuedIds);
+
+  if (updateError) {
+    throw new Error(`Created tasks but failed to mark queue rows queued: ${updateError.message}`);
+  }
+
+  return {
+    ok: true,
+    dryRun: false,
+    candidates: candidates.length,
+    tasksCreated: inserted?.length ?? taskRows.length,
+    queuedIds,
+  };
+}
+
+export async function getSupplyAcquisitionQueueSummary() {
+  const supabase = getSupabaseAdmin();
+  const { data, error } = await supabase
+    .from("hc_supply_acquisition_queue")
+    .select("hunt_status, priority, country_code, role_key")
+    .order("priority", { ascending: false, nullsFirst: false })
+    .limit(500);
+
+  if (error) {
+    throw new Error(`Failed to summarize hc_supply_acquisition_queue: ${error.message}`);
+  }
+
+  const rows = data ?? [];
+  const byStatus = rows.reduce<Record<string, number>>((acc, row: any) => {
+    const key = row.hunt_status || "unqueued";
+    acc[key] = (acc[key] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  return {
+    sampled: rows.length,
+    byStatus,
+    top: rows.slice(0, 10),
+  };
+}


### PR DESCRIPTION
## Summary
Adds executable cron bridges for the live `hc_supply_acquisition_queue` so directory supply gaps become `hc_command_tasks` instead of remaining inert database rows.

## What was upgraded
- `lib/directory/supply-acquisition-queue.ts`
  - Reads high-priority `hc_supply_acquisition_queue` rows.
  - Creates `hc_command_tasks` with `task_type=supply.acquire` and `agent_slug=supply-acquisition-worker`.
  - Marks queue rows as `queued` with `last_hunted_at` after task creation.
  - Provides a queue summary helper.
- `app/api/cron/supply-density/route.ts`
  - Adds the scheduled route already referenced by `vercel.json`.
  - GET reports queue health; POST queues acquisition work.
- `app/api/cron/partner-hunt/route.ts`
  - Adds the scheduled route already referenced by `vercel.json` and bridges ready supply gaps into acquisition tasks.
- `app/api/cron/listing-rescue/route.ts`
  - Adds the scheduled route already referenced by `vercel.json` and drains queued/open supply gaps into command tasks.

## Why it matters
Haul Command’s live database already knows where the 120-country / role-country supply gaps are. This makes those gaps executable through the existing command-task system, which is the next step toward completing directory coverage rather than only reporting missing supply.

## Verification
- `npm run typecheck` passed.
- `npm test -- tests/unit/directory-search-aliases.test.ts tests/unit/directory-query.test.ts tests/unit/directory-route-builders.test.ts` passed: 13 tests.
- `git diff --check` passed.

## Risk / rollback notes
- These routes require internal request auth through the existing `requireInternalRequest` helper. They do not expose unauthenticated queue mutation.
- The bridge creates command tasks and marks source queue rows as queued only after inserts succeed.
- Roll back by reverting this commit if task volume needs to pause.

## Follow-up
- After production deploy, verify `GET /api/cron/supply-density` with internal auth and run a small dry-run POST before allowing larger batches.
- Next step is a real `supply-acquisition-worker` drain implementation that consumes `hc_command_tasks` and writes discovered entities back to Supabase with proof/source metadata.